### PR TITLE
Add support for RegExp keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Each of these can be accessed as `Entity.attribute`, e.g. if one of the input's 
 
 > Note that only those attributes present in the input will be copied into the `Entity`, i.e. if your input has no links, `Entity.links` will not be set, rather than being an empty array.
 
-#### `Entity.hasXByY(String key)`
+#### `Entity.hasXByY(String|RegExp key)`
 
-Returns true if the Entity has an _X_ with a _Y_ of `key`, otherwise false.
+Returns true if the Entity has an _X_ with a _Y_ of `key` (or which matches `RegExp key`), otherwise false.
 
 * `hasActionByName(name)` (`hasAction(name)`) - returns true if any action on the entity has an action named `name`
 * `hasActionByClass(class)`
@@ -125,9 +125,9 @@ resource.hasLinkByRel('crazy'); // true
 resource.hasProperty('three'); // false
 ```
 
-#### `Entity.getXByY(String key)`
+#### `Entity.getXByY(String|RegExp key)`
 
-Returns the resource(s) of type _X_ with a _Y_ value of `key`. If the requested _X_ is singular, then the result is either the matching instance of _X_, or undefined. If the requested _X_ is plural, then the result is either an Array of the matching instances of _X_, or an empty Array.
+Returns the resource(s) of type _X_ with a _Y_ value of `key` (or which matches `RegExp key`). If the requested _X_ is singular, then the result is either the matching instance of _X_, or undefined. If the requested _X_ is plural, then the result is either an Array of the matching instances of _X_, or an empty Array.
 
 * `getActionByName(name)` (`getAction(name)`) - returns [Action](#action) or undefined
 * `getActionByClass(class)` - returns [Action](#action) or undefined
@@ -193,9 +193,9 @@ Attributes:
 * `type` (string) _Must be a [Siren Action type][action types]_
 * `fields` (array of [Fields](#field))
 
-#### `Action.hasXByY(String key)`
+#### `Action.hasXByY(String|RegExp key)`
 
-Returns true if the Action has an _X_ with a _Y_ of `key`, otherwise false.
+Returns true if the Action has an _X_ with a _Y_ of `key` (or which matches `RegExp key`), otherwise false.
 
 * `hasFieldByName(name)` (`hasField(name)`) - returns true if any action on the entity has an action named `name`
 * `hasFieldByClass(class)`
@@ -207,9 +207,9 @@ resource.hasClass('foo'); // false
 resource.getActionByName('fancy-action').hasFieldByName('max'); // true
 ```
 
-#### `Action.getXByY(String key)`
+#### `Action.getXByY(String|RegExp key)`
 
-Returns the resource(s) of type _X_ with a _Y_ value of `key`. If the requested _X_ is singular, then the result is either the matching instance of _X_, or undefined. If the requested _X_ is plural, then the result is either an Array of the matching instances of _X_, or an empty Array.
+Returns the resource(s) of type _X_ with a _Y_ value of `key` (or which matches `RegExp key`). If the requested _X_ is singular, then the result is either the matching instance of _X_, or undefined. If the requested _X_ is plural, then the result is either an Array of the matching instances of _X_, or an empty Array.
 
 * `getFieldByName(name)` (`getField(name)`) - returns [Field](#field) or undefined
 * `getFieldByClass(class)` - returns [Field](#field) or undefined

--- a/src/Action.js
+++ b/src/Action.js
@@ -2,7 +2,8 @@
 
 const
 	assert = require('./assert'),
-	Field = require('./Field');
+	Field = require('./Field'),
+	util = require('./util');
 
 function Action(action) {
 	if (action instanceof Action) {
@@ -71,7 +72,7 @@ function Action(action) {
 }
 
 Action.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && this.class.indexOf(cls) > -1;
+	return this.class instanceof Array && util.contains(this.class, cls);
 };
 
 Action.prototype.hasField = function(fieldName) {
@@ -79,15 +80,15 @@ Action.prototype.hasField = function(fieldName) {
 };
 
 Action.prototype.hasFieldByName = function(fieldName) {
-	return this._fieldsByName.hasOwnProperty(fieldName);
+	return util.hasProperty(this._fieldsByName, fieldName);
 };
 
 Action.prototype.hasFieldByClass = function(fieldClass) {
-	return this._fieldsByClass.hasOwnProperty(fieldClass);
+	return util.hasProperty(this._fieldsByClass, fieldClass);
 };
 
 Action.prototype.hasFieldByType = function(fieldType) {
-	return this._fieldsByType.hasOwnProperty(fieldType);
+	return util.hasProperty(this._fieldsByType, fieldType);
 };
 
 Action.prototype.getField = function(fieldName) {
@@ -95,34 +96,26 @@ Action.prototype.getField = function(fieldName) {
 };
 
 Action.prototype.getFieldByName = function(fieldName) {
-	return this._fieldsByName[fieldName];
+	return util.getMatchingValue(this._fieldsByName, fieldName);
 };
 
 Action.prototype.getFieldByClass = function(fieldClass) {
-	return this._getFirstOrUndefined('_fieldsByClass', fieldClass);
-};
-
-Action.prototype.getFieldsByClass = function(fieldClass) {
-	return this._getSetOrEmpty('_fieldsByClass', fieldClass);
-};
-
-Action.prototype.getFieldByType = function(fieldType) {
-	return this._getFirstOrUndefined('_fieldsByType', fieldType);
-};
-
-Action.prototype.getFieldsByType = function(fieldType) {
-	return this._getSetOrEmpty('_fieldsByType', fieldType);
-};
-
-Action.prototype._getFirstOrUndefined = function(set, key) {
-	const vals = this[set][key];
-
+	const vals = util.getMatchingValue(this._fieldsByClass, fieldClass);
 	return vals ? vals[0] : undefined;
 };
 
-Action.prototype._getSetOrEmpty = function(set, key) {
-	const vals = this[set][key];
+Action.prototype.getFieldsByClass = function(fieldClass) {
+	const vals = util.getMatchingValue(this._fieldsByClass, fieldClass);
+	return vals ? vals.slice() : [];
+};
 
+Action.prototype.getFieldByType = function(fieldType) {
+	const vals = util.getMatchingValue(this._fieldsByType, fieldType);
+	return vals ? vals[0] : undefined;
+};
+
+Action.prototype.getFieldsByType = function(fieldType) {
+	const vals = util.getMatchingValue(this._fieldsByType, fieldType);
 	return vals ? vals.slice() : [];
 };
 

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const assert = require('./assert');
+const
+	assert = require('./assert'),
+	util = require('./util');
 
 const
 	Action = require('./Action'),
@@ -156,23 +158,23 @@ Entity.prototype.hasAction = function(actionName) {
 };
 
 Entity.prototype.hasActionByName = function(actionName) {
-	return this._actionsByName.hasOwnProperty(actionName);
+	return util.hasProperty(this._actionsByName, actionName);
 };
 
 Entity.prototype.hasActionByClass = function(actionClass) {
-	return this._actionsByClass.hasOwnProperty(actionClass);
+	return util.hasProperty(this._actionsByClass, actionClass);
 };
 
 Entity.prototype.hasActionByMethod = function(actionMethod) {
-	return this._actionsByMethod.hasOwnProperty(actionMethod);
+	return util.hasProperty(this._actionsByMethod, actionMethod);
 };
 
 Entity.prototype.hasActionByType = function(actionType) {
-	return this._actionsByType.hasOwnProperty(actionType);
+	return util.hasProperty(this._actionsByType, actionType);
 };
 
 Entity.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && this.class.indexOf(cls) > -1;
+	return this.class instanceof Array && util.contains(this.class, cls);
 };
 
 Entity.prototype.hasEntity = function(entityRel) {
@@ -180,15 +182,15 @@ Entity.prototype.hasEntity = function(entityRel) {
 };
 
 Entity.prototype.hasEntityByRel = function(entityRel) {
-	return this._entitiesByRel.hasOwnProperty(entityRel);
+	return util.hasProperty(this._entitiesByRel, entityRel);
 };
 
 Entity.prototype.hasEntityByClass = function(entityClass) {
-	return this._entitiesByClass.hasOwnProperty(entityClass);
+	return util.hasProperty(this._entitiesByClass, entityClass);
 };
 
 Entity.prototype.hasEntityByType = function(entityType) {
-	return this._entitiesByType.hasOwnProperty(entityType);
+	return util.hasProperty(this._entitiesByType, entityType);
 };
 
 Entity.prototype.hasLink = function(linkRel) {
@@ -196,19 +198,19 @@ Entity.prototype.hasLink = function(linkRel) {
 };
 
 Entity.prototype.hasLinkByRel = function(linkRel) {
-	return this._linksByRel.hasOwnProperty(linkRel);
+	return util.hasProperty(this._linksByRel, linkRel);
 };
 
 Entity.prototype.hasLinkByClass = function(linkClass) {
-	return this._linksByClass.hasOwnProperty(linkClass);
+	return util.hasProperty(this._linksByClass, linkClass);
 };
 
 Entity.prototype.hasLinkByType = function(linkType) {
-	return this._linksByType.hasOwnProperty(linkType);
+	return util.hasProperty(this._linksByType, linkType);
 };
 
 Entity.prototype.hasProperty = function(property) {
-	return this.hasOwnProperty('properties') && this.properties.hasOwnProperty(property);
+	return util.hasProperty(this, 'properties') && util.hasProperty(this.properties, property);
 };
 
 Entity.prototype.getAction = function(actionName) {
@@ -216,31 +218,37 @@ Entity.prototype.getAction = function(actionName) {
 };
 
 Entity.prototype.getActionByName = function(actionName) {
-	return this._actionsByName[actionName];
+	return util.getMatchingValue(this._actionsByName, actionName);
 };
 
 Entity.prototype.getActionByClass = function(actionClass) {
-	return this._getFirstOrUndefined('_actionsByClass', actionClass);
+	const vals = util.getMatchingValue(this._actionsByClass, actionClass);
+	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByClass = function(actionClass) {
-	return this._getSetOrEmpty('_actionsByClass', actionClass);
+	const vals = util.getMatchingValue(this._actionsByClass, actionClass);
+	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getActionByMethod = function(actionMethod) {
-	return this._getFirstOrUndefined('_actionsByMethod', actionMethod);
+	const vals = util.getMatchingValue(this._actionsByMethod, actionMethod);
+	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByMethod = function(actionMethod) {
-	return this._getSetOrEmpty('_actionsByMethod', actionMethod);
+	const vals = util.getMatchingValue(this._actionsByMethod, actionMethod);
+	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getActionByType = function(actionType) {
-	return this._getFirstOrUndefined('_actionsByType', actionType);
+	const vals = util.getMatchingValue(this._actionsByType, actionType);
+	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByType = function(actionType) {
-	return this._getSetOrEmpty('_actionsByType', actionType);
+	const vals = util.getMatchingValue(this._actionsByType, actionType);
+	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getLink = function(linkRel) {
@@ -252,27 +260,33 @@ Entity.prototype.getLinks = function(linkRel) {
 };
 
 Entity.prototype.getLinkByRel = function(linkRel) {
-	return this._getFirstOrUndefined('_linksByRel', linkRel);
+	const vals = util.getMatchingValue(this._linksByRel, linkRel);
+	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByRel = function(linkRel) {
-	return this._getSetOrEmpty('_linksByRel', linkRel);
+	const vals = util.getMatchingValue(this._linksByRel, linkRel);
+	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getLinkByClass = function(linkClass) {
-	return this._getFirstOrUndefined('_linksByClass', linkClass);
+	const vals = util.getMatchingValue(this._linksByClass, linkClass);
+	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByClass = function(linkClass) {
-	return this._getSetOrEmpty('_linksByClass', linkClass);
+	const vals = util.getMatchingValue(this._linksByClass, linkClass);
+	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getLinkByType = function(linkType) {
-	return this._getFirstOrUndefined('_linksByType', linkType);
+	const vals = util.getMatchingValue(this._linksByType, linkType);
+	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByType = function(linkType) {
-	return this._getSetOrEmpty('_linksByType', linkType);
+	const vals = util.getMatchingValue(this._linksByType, linkType);
+	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getSubEntity = function(entityRel) {
@@ -284,38 +298,32 @@ Entity.prototype.getSubEntities = function(entityRel) {
 };
 
 Entity.prototype.getSubEntityByRel = function(entityRel) {
-	return this._getFirstOrUndefined('_entitiesByRel', entityRel);
-};
-
-Entity.prototype.getSubEntitiesByRel = function(entityRel) {
-	return this._getSetOrEmpty('_entitiesByRel', entityRel);
-};
-
-Entity.prototype.getSubEntityByClass = function(entityClass) {
-	return this._getFirstOrUndefined('_entitiesByClass', entityClass);
-};
-
-Entity.prototype.getSubEntitiesByClass = function(entityClass) {
-	return this._getSetOrEmpty('_entitiesByClass', entityClass);
-};
-
-Entity.prototype.getSubEntityByType = function(entityType) {
-	return this._getFirstOrUndefined('_entitiesByType', entityType);
-};
-
-Entity.prototype.getSubEntitiesByType = function(entityType) {
-	return this._getSetOrEmpty('_entitiesByType', entityType);
-};
-
-Entity.prototype._getFirstOrUndefined = function(set, key) {
-	const vals = this[set][key];
-
+	const vals = util.getMatchingValue(this._entitiesByRel, entityRel);
 	return vals ? vals[0] : undefined;
 };
 
-Entity.prototype._getSetOrEmpty = function(set, key) {
-	const vals = this[set][key];
+Entity.prototype.getSubEntitiesByRel = function(entityRel) {
+	const vals = util.getMatchingValue(this._entitiesByRel, entityRel);
+	return vals ? vals.slice() : [];
+};
 
+Entity.prototype.getSubEntityByClass = function(entityClass) {
+	const vals = util.getMatchingValue(this._entitiesByClass, entityClass);
+	return vals ? vals[0] : undefined;
+};
+
+Entity.prototype.getSubEntitiesByClass = function(entityClass) {
+	const vals = util.getMatchingValue(this._entitiesByClass, entityClass);
+	return vals ? vals.slice() : [];
+};
+
+Entity.prototype.getSubEntityByType = function(entityType) {
+	const vals = util.getMatchingValue(this._entitiesByType, entityType);
+	return vals ? vals[0] : undefined;
+};
+
+Entity.prototype.getSubEntitiesByType = function(entityType) {
+	const vals = util.getMatchingValue(this._entitiesByType, entityType);
 	return vals ? vals.slice() : [];
 };
 

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const assert = require('./assert');
+const
+	assert = require('./assert'),
+	util = require('./util');
 
 const VALID_TYPES = [
 	'hidden',
@@ -62,7 +64,7 @@ function Field(field) {
 }
 
 Field.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && this.class.indexOf(cls) > -1;
+	return this.class instanceof Array && util.contains(this.class, cls);
 };
 
 module.exports = Field;

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const assert = require('./assert');
+const
+	assert = require('./assert'),
+	util = require('./util');
 
 function Link(link) {
 	if (link instanceof Link) {
@@ -37,7 +39,7 @@ function Link(link) {
 }
 
 Link.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && this.class.indexOf(cls) > -1;
+	return this.class instanceof Array && util.contains(this.class, cls);
 };
 
 module.exports = Link;

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,42 @@
+'use strict';
+
+function contains(arrayLike, stringOrRegex) {
+	if ('string' === typeof stringOrRegex) {
+		return arrayLike.indexOf(stringOrRegex) > -1;
+	}
+
+	const match = arrayLike.find(function(item) {
+		return item.match(stringOrRegex);
+	});
+
+	return (match !== undefined);
+}
+
+function hasProperty(objectLike, stringOrRegex) {
+	if ('string' === typeof stringOrRegex) {
+		return objectLike.hasOwnProperty(stringOrRegex);
+	}
+
+	return contains(Object.keys(objectLike), stringOrRegex);
+}
+
+function getMatchingValue(objectLike, stringOrRegex) {
+	if ('string' === typeof stringOrRegex) {
+		return objectLike[stringOrRegex];
+	}
+
+	const keys = Object.keys(objectLike);
+	for (var i = 0; i < keys.length; i++) {
+		const key = keys[i];
+
+		if (key.match(stringOrRegex)) {
+			return objectLike[key];
+		}
+	}
+}
+
+module.exports = {
+	contains: contains,
+	hasProperty: hasProperty,
+	getMatchingValue: getMatchingValue
+};

--- a/test/action.js
+++ b/test/action.js
@@ -183,6 +183,9 @@ describe('Action', function() {
 					siren = buildAction();
 					expect(siren.hasClass('foo')).to.be.true;
 
+					expect(siren.hasClass(/foo/)).to.be.true;
+					expect(siren.hasClass(/bar/)).to.be.false;
+
 					resource.class = undefined;
 					siren = buildAction();
 					expect(siren.hasClass('foo')).to.be.false;
@@ -197,6 +200,9 @@ describe('Action', function() {
 					siren = buildAction();
 					expect(siren.hasField('foo')).to.be.true;
 
+					expect(siren.hasField(/foo/)).to.be.true;
+					expect(siren.hasField(/bar/)).to.be.false;
+
 					resource.fields = undefined;
 					siren = buildAction();
 					expect(siren.hasField('foo')).to.be.false;
@@ -210,6 +216,9 @@ describe('Action', function() {
 					siren = buildAction();
 					expect(siren.hasFieldByClass('bar')).to.be.true;
 
+					expect(siren.hasFieldByClass(/bar/)).to.be.true;
+					expect(siren.hasFieldByClass(/foo/)).to.be.false;
+
 					resource.fields = undefined;
 					siren = buildAction();
 					expect(siren.hasFieldByClass('bar')).to.be.false;
@@ -222,6 +231,9 @@ describe('Action', function() {
 					}];
 					siren = buildAction();
 					expect(siren.hasFieldByType('text')).to.be.true;
+
+					expect(siren.hasFieldByType(/text/)).to.be.true;
+					expect(siren.hasFieldByType(/nope/)).to.be.false;
 
 					resource.fields = undefined;
 					siren = buildAction();
@@ -250,26 +262,41 @@ describe('Action', function() {
 				it('getFieldByName (getField)', function() {
 					expect(siren.getField('foo')).to.have.property('title', 'bar');
 					expect(siren.getField('nope')).to.be.undefined;
+
+					expect(siren.getField(/foo/)).to.not.be.undefined;
+					expect(siren.getField(/bar/)).to.be.undefined;
 				});
 
 				it('getFieldByClass', function() {
 					expect(siren.getFieldByClass('baz')).to.have.property('title', 'bar');
 					expect(siren.getFieldByClass('nope')).to.be.undefined;
+
+					expect(siren.getFieldByClass(/baz/)).to.not.be.undefined;
+					expect(siren.getFieldByClass(/foo/)).to.be.undefined;
 				});
 
 				it('getFieldsByClass', function() {
 					expect(siren.getFieldsByClass('baz')).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getFieldsByClass('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+
+					expect(siren.getFieldsByClass(/baz/)).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getFieldsByClass(/foo/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getFieldByType', function() {
 					expect(siren.getFieldByType('text')).to.have.property('title', 'bar');
 					expect(siren.getFieldByType('nope')).to.be.undefined;
+
+					expect(siren.getFieldByType(/text/)).to.have.property('title', 'bar');
+					expect(siren.getFieldByType(/nope/)).to.be.undefined;
 				});
 
 				it('getFieldsByType', function() {
 					expect(siren.getFieldsByType('text')).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getFieldsByType('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+
+					expect(siren.getFieldsByType(/text/)).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getFieldsByType(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 			});
 		});

--- a/test/entity.js
+++ b/test/entity.js
@@ -202,6 +202,9 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.hasAction('foo')).to.be.true;
 
+					expect(siren.hasAction(/foo/)).to.be.true;
+					expect(siren.hasAction(/bar/)).to.be.false;
+
 					resource.actions = undefined;
 					siren = buildEntity();
 					expect(siren.hasAction('foo')).to.be.false;
@@ -215,6 +218,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.hasActionByClass('baz')).to.be.true;
+
+					expect(siren.hasActionByClass(/baz/)).to.be.true;
+					expect(siren.hasActionByClass(/foo/)).to.be.false;
 
 					resource.actions = undefined;
 					siren = buildEntity();
@@ -230,6 +236,9 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.hasActionByMethod('GET')).to.be.true;
 
+					expect(siren.hasActionByMethod(/GET/)).to.be.true;
+					expect(siren.hasActionByMethod(/PUT/)).to.be.false;
+
 					resource.actions = undefined;
 					siren = buildEntity();
 					expect(siren.hasActionByMethod('GET')).to.be.false;
@@ -244,6 +253,9 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.hasActionByType('application/x-www-form-urlencoded')).to.be.true;
 
+					expect(siren.hasActionByType(/urlencoded/)).to.be.true;
+					expect(siren.hasActionByType(/foo/)).to.be.false;
+
 					resource.actions = undefined;
 					siren = buildEntity();
 					expect(siren.hasActionByType('application/x-www-form-urlencoded')).to.be.false;
@@ -255,6 +267,9 @@ describe('Entity', function() {
 					resource.class = ['foo'];
 					siren = buildEntity();
 					expect(siren.hasClass('foo')).to.be.true;
+
+					expect(siren.hasClass(/foo/)).to.be.true;
+					expect(siren.hasClass(/bar/)).to.be.false;
 
 					resource.class = undefined;
 					siren = buildEntity();
@@ -270,6 +285,9 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.hasEntity('foo')).to.be.true;
 
+					expect(siren.hasEntity(/foo/)).to.be.true;
+					expect(siren.hasEntity(/bar/)).to.be.false;
+
 					resource.entities = undefined;
 					siren = buildEntity();
 					expect(siren.hasEntity('foo')).to.be.false;
@@ -283,6 +301,9 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.hasEntityByClass('bar')).to.be.true;
 
+					expect(siren.hasEntityByClass(/bar/)).to.be.true;
+					expect(siren.hasEntityByClass(/baz/)).to.be.false;
+
 					resource.entities = undefined;
 					siren = buildEntity();
 					expect(siren.hasEntityByClass('bar')).to.be.false;
@@ -295,6 +316,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.hasEntityByType('bar')).to.be.true;
+
+					expect(siren.hasEntityByType(/bar/)).to.be.true;
+					expect(siren.hasEntityByType(/baz/)).to.be.false;
 
 					resource.entities = undefined;
 					siren = buildEntity();
@@ -311,6 +335,9 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.hasLink('foo')).to.be.true;
 
+					expect(siren.hasLink(/foo/)).to.be.true;
+					expect(siren.hasLink(/bar/)).to.be.false;
+
 					resource.links = undefined;
 					siren = buildEntity();
 					expect(siren.hasLink('foo')).to.be.false;
@@ -324,6 +351,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.hasLinkByClass('baz')).to.be.true;
+
+					expect(siren.hasLinkByClass(/baz/)).to.be.true;
+					expect(siren.hasLinkByClass(/foo/)).to.be.false;
 
 					resource.links = undefined;
 					siren = buildEntity();
@@ -339,6 +369,9 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.hasLinkByType('baz')).to.be.true;
 
+					expect(siren.hasLinkByType(/baz/)).to.be.true;
+					expect(siren.hasLinkByType(/foo/)).to.be.false;
+
 					resource.links = undefined;
 					siren = buildEntity();
 					expect(siren.hasLinkByType('baz')).to.be.false;
@@ -350,6 +383,9 @@ describe('Entity', function() {
 					resource.properties = { foo: 'bar' };
 					siren = buildEntity();
 					expect(siren.hasProperty('foo')).to.be.true;
+
+					expect(siren.hasProperty(/foo/)).to.be.true;
+					expect(siren.hasProperty(/bar/)).to.be.false;
 
 					resource.properties = undefined;
 					siren = buildEntity();
@@ -367,6 +403,7 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.getAction('foo')).to.have.property('href', 'bar');
+					expect(siren.getAction(/foo/)).to.have.property('href', 'bar');
 				});
 
 				it('getActionByClass', function() {
@@ -377,6 +414,10 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.getActionByClass('baz')).to.have.property('href', 'bar');
+					expect(siren.getActionByClass(/baz/)).to.have.property('href', 'bar');
+					expect(siren.getActionByClass('foo')).to.be.undefined;
+					expect(siren.getActionByClass(/foo/)).to.be.undefined;
+
 				});
 
 				it('getActionsByClass', function() {
@@ -391,6 +432,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.getActionsByClass('baz')).to.have.lengthOf(2);
+					expect(siren.getActionsByClass(/baz/)).to.have.lengthOf(2);
+					expect(siren.getActionsByClass('foo')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getActionsByClass(/foo/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getActionByMethod', function() {
@@ -401,6 +445,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.getActionByMethod('GET')).to.have.property('href', 'bar');
+					expect(siren.getActionByMethod(/GET/)).to.have.property('href', 'bar');
+					expect(siren.getActionByMethod('PUT')).to.be.undefined;
+					expect(siren.getActionByMethod(/PUT/)).to.be.undefined;
 				});
 
 				it('getActionsByMethod', function() {
@@ -415,6 +462,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.getActionsByMethod('GET')).to.have.lengthOf(2);
+					expect(siren.getActionsByMethod(/GET/)).to.have.lengthOf(2);
+					expect(siren.getActionsByMethod('PUT')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getActionsByMethod(/PUT/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getActionByType', function() {
@@ -425,6 +475,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.getActionByType('application/x-www-form-urlencoded')).to.have.property('href', 'bar');
+					expect(siren.getActionByType(/urlencoded/)).to.have.property('href', 'bar');
+					expect(siren.getActionByType('foo')).to.be.undefined;
+					expect(siren.getActionByType(/foo/)).to.be.undefined;
 				});
 
 				it('getActionsByType', function() {
@@ -439,6 +492,9 @@ describe('Entity', function() {
 					}];
 					siren = buildEntity();
 					expect(siren.getActionsByType('application/x-www-form-urlencoded')).to.have.lengthOf(2);
+					expect(siren.getActionsByType(/urlencoded/)).to.have.lengthOf(2);
+					expect(siren.getActionsByType('foo')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getActionsByType(/foo/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 			});
 
@@ -460,36 +516,49 @@ describe('Entity', function() {
 
 				it('getLinkByRel (getLink)', function() {
 					expect(siren.getLink('foo')).to.have.property('href', 'bar');
+					expect(siren.getLink(/foo/)).to.have.property('href', 'bar');
 					expect(siren.getLink('nope')).to.be.undefined;
+					expect(siren.getLink(/nope/)).to.be.undefined;
 				});
 
 				it('getLinksByRel (getLinks)', function() {
 					expect(siren.getLinks('foo')).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getLinks(/foo/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getLinks('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getLinks(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getLinks should return a new array', function() {
 					expect(siren.getLinks('foo')).to.not.equal(siren.getLinks('foo'));
+					expect(siren.getLinks(/foo/)).to.not.equal(siren.getLinks('foo'));
 				});
 
 				it('getLinkByClass', function() {
 					expect(siren.getLinkByClass('baz')).to.have.property('href', 'bar');
+					expect(siren.getLinkByClass(/baz/)).to.have.property('href', 'bar');
 					expect(siren.getLinkByClass('nope')).to.be.undefined;
+					expect(siren.getLinkByClass(/nope/)).to.be.undefined;
 				});
 
 				it('getLinksByClass', function() {
 					expect(siren.getLinksByClass('baz')).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getLinksByClass(/baz/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getLinksByClass('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getLinksByClass(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getLinkByType', function() {
 					expect(siren.getLinkByType('quux')).to.have.property('href', 'bar');
+					expect(siren.getLinkByType(/quux/)).to.have.property('href', 'bar');
 					expect(siren.getLinkByType('nope')).to.be.undefined;
+					expect(siren.getLinkByType(/nope/)).to.be.undefined;
 				});
 
 				it('getLinksByType', function() {
 					expect(siren.getLinksByType('quux')).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getLinksByType(/quux/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getLinksByType('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getLinksByType(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 			});
 
@@ -511,36 +580,49 @@ describe('Entity', function() {
 
 				it('getSubEntityByRel (getSubEntity)', function() {
 					expect(siren.getSubEntity('foo')).to.have.property('title', 'bar');
+					expect(siren.getSubEntity(/foo/)).to.have.property('title', 'bar');
 					expect(siren.getSubEntity('nope')).to.be.undefined;
+					expect(siren.getSubEntity(/nope/)).to.be.undefined;
 				});
 
 				it('getSubEntitiesByRel (getSubEntities)', function() {
 					expect(siren.getSubEntities('foo')).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getSubEntities(/foo/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getSubEntities('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getSubEntities(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getSubEntities should return a new array', function() {
 					expect(siren.getSubEntities('foo')).to.not.equal(siren.getSubEntities('foo'));
+					expect(siren.getSubEntities(/foo/)).to.not.equal(siren.getSubEntities('foo'));
 				});
 
 				it('getSubEntityByClass', function() {
 					expect(siren.getSubEntityByClass('baz')).to.have.property('title', 'bar');
+					expect(siren.getSubEntityByClass(/baz/)).to.have.property('title', 'bar');
 					expect(siren.getSubEntityByClass('nope')).to.be.undefined;
+					expect(siren.getSubEntityByClass(/nope/)).to.be.undefined;
 				});
 
 				it('getSubEntitiesByClass', function() {
 					expect(siren.getSubEntitiesByClass('baz')).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getSubEntitiesByClass(/baz/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getSubEntitiesByClass('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getSubEntitiesByClass(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getSubEntityByType', function() {
 					expect(siren.getSubEntityByType('quux')).to.have.property('title', 'bar');
+					expect(siren.getSubEntityByType(/quux/)).to.have.property('title', 'bar');
 					expect(siren.getSubEntityByType('nope')).to.be.undefined;
+					expect(siren.getSubEntityByType(/nope/)).to.be.undefined;
 				});
 
 				it('getSubEntitiesByType', function() {
 					expect(siren.getSubEntitiesByType('quux')).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getSubEntitiesByType(/quux/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getSubEntitiesByType('nope')).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getSubEntitiesByType(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 			});
 		});

--- a/test/field.js
+++ b/test/field.js
@@ -90,6 +90,9 @@ describe('Field', function() {
 			siren = buildField();
 			expect(siren.hasClass('foo')).to.be.true;
 
+			expect(siren.hasClass(/foo/)).to.be.true;
+			expect(siren.hasClass(/bar/)).to.be.false;
+
 			resource.class = undefined;
 			siren = buildField();
 			expect(siren.hasClass('foo')).to.be.false;

--- a/test/link.js
+++ b/test/link.js
@@ -100,6 +100,9 @@ describe('Link', function() {
 			siren = buildLink();
 			expect(siren.hasClass('foo')).to.be.true;
 
+			expect(siren.hasClass(/foo/)).to.be.true;
+			expect(siren.hasClass(/bar/)).to.be.false;
+
 			resource.class = undefined;
 			siren = buildLink();
 			expect(siren.hasClass('foo')).to.be.false;


### PR DESCRIPTION
If a rel is not an IANA rel, it should be a FQDN. This means that there could be some variance in the rel string, depending on where said rels are defined. This change supports passing a regex to the various `hasXByY` and `getXByY` functions, which allows for cases where the entire rel can vary to be handled cleanly.

(The other option is to basically offload this work outside the client, and not use the various helper methods.)