### PR TITLE
Fix "entity is undefined"

### DIFF
--- a/src/Entity.js
+++ b/src/Entity.js
@@ -9,6 +9,8 @@ const
 	Link = require('./Link');
 
 function Entity(entity) {
+	entity = entity || {};
+
 	if (entity instanceof Entity) {
 		return entity;
 	}

--- a/test/entity.js
+++ b/test/entity.js
@@ -45,6 +45,11 @@ describe('Entity', function() {
 		expect(buildEntity()).to.be.an('object');
 	});
 
+	it('should return an empty entity if nothing is passed', function() {
+		resource = undefined;
+		expect(buildEntity()).to.be.an('object');
+	});
+
 	describe('title', function() {
 		it('should parse title', function() {
 			resource.title = 'A title!';


### PR DESCRIPTION
This was noticed in d2l-my-courses, which uses d2l-siren-parser, which uses this. If the passed entity is undefined for whatever reason, then things crap out on trying to find out if the rel exists. To safely navigate this, and always ensure entity.getXByY and other functions work, return an empty entity if undefined or null was passed.