### PR TITLE
Change from Parser to Parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and then `require` it as you would any other npm package. Alternatively, the par
 <script src="https://s.brightspace.com/lib/siren-parser/{version}/siren-parser.js"></script>
 
 <script>
-var parsedEntity = window.D2L.Hypermedia.Siren.Parser('{"class":["foo","bar"]}');
+var parsedEntity = window.D2L.Hypermedia.Siren.Parse('{"class":["foo","bar"]}');
 </script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/Entity.js",
   "scripts": {
     "prebrowserify": "rimraf dist && mkdir dist",
-    "browserify": "browserify -g uglifyify -s 'D2L.Hypermedia.Siren.Parser' src/Entity.js > ./dist/siren-parser.js",
+    "browserify": "browserify -g uglifyify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "npm run lint && npm run test-no-style",
     "test-no-style": "export NODE_ENV=test; istanbul cover --source-map --dir ./coverage/unit --root src/ node_modules/.bin/_mocha -- --recursive ./test",


### PR DESCRIPTION
This makes more sense for the normal use case, e.g. window.D2L.Hypermedia.Siren.Parse(aThing) - having Parser() makes it sound like a constructor, which it isn't. (I mean, it's kind of an Entity constructor, but not a Parser constructor.)