### PR TITLE
hasEntityByX -> hasSubEntityByX

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ Each of these can be accessed as `Entity.attribute`, e.g. if one of the input's 
 
 Returns true if the Entity has an _X_ with a _Y_ of `key` (or which matches `RegExp key`), otherwise false.
 
-* `hasActionByName(name)` (`hasAction(name)`) - returns true if any action on the entity has an action named `name`
+* `hasActionByName(name)`
 * `hasActionByClass(class)`
 * `hasClass(class)`
-* `hasEntityByRel(rel)` (`hasEntity(rel)`)
-* `hasEntityByClass(class)`
-* `hasEntityByType(type)`
-* `hasLinkByRel(rel)` (`hasLink(rel)`)
+* `hasSubEntityByRel(rel)`
+* `hasSubEntityByClass(class)`
+* `hasSubEntityByType(type)`
+* `hasLinkByRel(rel)`
 * `hasLinkByClass(class)`
 * `hasLinkByType(type)`
 * `hasProperty(prop)`
@@ -137,8 +137,8 @@ Returns true if the Entity has an _X_ with a _Y_ of `key` (or which matches `Reg
 ```js
 resource.hasActionByName('fancy-action'); // true
 resource.hasClass('inner'); // false
-resource.hasEntityByRel('child'); // true
-resource.hasEntityByType('child'); // false
+resource.hasSubEntityByRel('child'); // true
+resource.hasSubEntityByType('child'); // false
 resource.hasLinkByRel('crazy'); // true
 resource.hasProperty('three'); // false
 ```
@@ -147,19 +147,19 @@ resource.hasProperty('three'); // false
 
 Returns the resource(s) of type _X_ with a _Y_ value of `key` (or which matches `RegExp key`). If the requested _X_ is singular, then the result is either the matching instance of _X_, or undefined. If the requested _X_ is plural, then the result is either an Array of the matching instances of _X_, or an empty Array.
 
-* `getActionByName(name)` (`getAction(name)`) - returns [Action](#action) or undefined
+* `getActionByName(name)` - returns [Action](#action) or undefined
 * `getActionByClass(class)` - returns [Action](#action) or undefined
-* `getLinkByRel(rel)` (`getLink(rel)`) - returns [Link](#link) or undefined
+* `getLinkByRel(rel)` - returns [Link](#link) or undefined
 * `getLinkByClass(class)` - returns [Link](#link) or undefined
 * `getLinkByType(type)` - returns [Link](#link) or undefined
 * `getSubEntityByRel(rel)` (`getSubEntity(rel)`) - returns [Entity](#entity) or undefined
 * `getSubEntityByClass(class)` - returns [Entity](#entity) or undefined
 * `getSubEntityByType(type)` - returns [Entity](#entity) or undefined
 * `getActionsByClass(class)` - returns Array of [Actions](#action) (empty Array if none match)
-* `getLinksByRel(rel)` (`getLinks(rel)`) - returns Array of [Links](#link) (empty Array if none match)
+* `getLinksByRel(rel)` - returns Array of [Links](#link) (empty Array if none match)
 * `getLinksByClass(class)` - returns Array of [Links](#link) (empty Array if none match)
 * `getLinksByType(type)` - returns Array of [Links](#link) (empty Array if none match)
-* `getSubEntitiesByRel(rel)` (`getSubEntities(rel)`) - returns Array of [Entities](#entity) (empty Array if none match)
+* `getSubEntitiesByRel(rel)` - returns Array of [Entities](#entity) (empty Array if none match)
 * `getSubEntitiesByClass(class)` - returns Array of [Entities](#entity) (empty Array if none match)
 * `getSubEntitiesByType(type)` - returns Array of [Entities](#entity) (empty Array if none match)
 

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -180,18 +180,30 @@ Entity.prototype.hasClass = function(cls) {
 };
 
 Entity.prototype.hasEntity = function(entityRel) {
-	return this.hasEntityByRel(entityRel);
+	return this.hasSubEntityByRel(entityRel);
 };
 
 Entity.prototype.hasEntityByRel = function(entityRel) {
+	return this.hasSubEntityByRel(entityRel);
+};
+
+Entity.prototype.hasSubEntityByRel = function(entityRel) {
 	return util.hasProperty(this._entitiesByRel, entityRel);
 };
 
 Entity.prototype.hasEntityByClass = function(entityClass) {
+	return this.hasSubEntityByClass(entityClass);
+};
+
+Entity.prototype.hasSubEntityByClass = function(entityClass) {
 	return util.hasProperty(this._entitiesByClass, entityClass);
 };
 
 Entity.prototype.hasEntityByType = function(entityType) {
+	return this.hasSubEntityByType(entityType);
+};
+
+Entity.prototype.hasSubEntityByType = function(entityType) {
 	return util.hasProperty(this._entitiesByType, entityType);
 };
 

--- a/test/entity.js
+++ b/test/entity.js
@@ -283,51 +283,67 @@ describe('Entity', function() {
 			});
 
 			describe('Entity', function() {
-				it('hasEntityByRel (hasEntity)', function() {
+				it('hasSubEntityByRel (hasEntityByRel, hasEntity)', function() {
 					resource.entities = [{
 						rel: ['foo']
 					}];
 					siren = buildEntity();
 					expect(siren.hasEntity('foo')).to.be.true;
+					expect(siren.hasEntityByRel('foo')).to.be.true;
+					expect(siren.hasSubEntityByRel('foo')).to.be.true;
 
-					expect(siren.hasEntity(/foo/)).to.be.true;
 					expect(siren.hasEntity(/bar/)).to.be.false;
+					expect(siren.hasEntityByRel(/foo/)).to.be.true;
+					expect(siren.hasSubEntityByRel(/foo/)).to.be.true;
+					expect(siren.hasEntity(/bar/)).to.be.false;
+					expect(siren.hasEntityByRel(/foo/)).to.be.true;
+					expect(siren.hasSubEntityByRel(/foo/)).to.be.true;
 
 					resource.entities = undefined;
 					siren = buildEntity();
 					expect(siren.hasEntity('foo')).to.be.false;
+					expect(siren.hasEntityByRel('foo')).to.be.false;
+					expect(siren.hasSubEntityByRel('foo')).to.be.false;
 				});
 
-				it('hasEntityByClass', function() {
+				it('hasSubEntityByClass (hasEntityByClass)', function() {
 					resource.entities = [{
 						rel: ['foo'],
 						class: ['bar']
 					}];
 					siren = buildEntity();
 					expect(siren.hasEntityByClass('bar')).to.be.true;
+					expect(siren.hasSubEntityByClass('bar')).to.be.true;
 
 					expect(siren.hasEntityByClass(/bar/)).to.be.true;
+					expect(siren.hasSubEntityByClass(/bar/)).to.be.true;
 					expect(siren.hasEntityByClass(/baz/)).to.be.false;
+					expect(siren.hasSubEntityByClass(/baz/)).to.be.false;
 
 					resource.entities = undefined;
 					siren = buildEntity();
 					expect(siren.hasEntityByClass('bar')).to.be.false;
+					expect(siren.hasSubEntityByClass('bar')).to.be.false;
 				});
 
-				it('hasEntityByType', function() {
+				it('hasSubEntityByType (hasSubEntityByType)', function() {
 					resource.entities = [{
 						rel: ['foo'],
 						type: 'bar'
 					}];
 					siren = buildEntity();
 					expect(siren.hasEntityByType('bar')).to.be.true;
+					expect(siren.hasSubEntityByType('bar')).to.be.true;
 
 					expect(siren.hasEntityByType(/bar/)).to.be.true;
+					expect(siren.hasSubEntityByType(/bar/)).to.be.true;
 					expect(siren.hasEntityByType(/baz/)).to.be.false;
+					expect(siren.hasSubEntityByType(/baz/)).to.be.false;
 
 					resource.entities = undefined;
 					siren = buildEntity();
 					expect(siren.hasEntityByType('bar')).to.be.false;
+					expect(siren.hasSubEntityByType('bar')).to.be.false;
 				});
 			});
 


### PR DESCRIPTION
Noticed by Jeff, the naming here was inconsistent. So, fixed.

Also removed the documentation referring to the older methods, since they'll be removed in the next major version bump.