### PR TITLE
DE26356: Use deUMDify to remove the Universal Module Definition from …

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "src/Entity.js",
   "scripts": {
     "prebrowserify": "rimraf dist && mkdir dist",
-    "browserify": "browserify -g uglifyify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
+    "browserify": "npm run browserify:umd && npm run browserify:global",
+    "browserify:umd": "browserify -g uglifyify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
+    "browserify:global": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser-global.js",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "npm run lint && npm run test-no-style",
     "test-no-style": "export NODE_ENV=test; istanbul cover --source-map --dir ./coverage/unit --root src/ node_modules/.bin/_mocha -- --recursive ./test",
@@ -41,6 +43,7 @@
     "browserify": "^14.1.0",
     "chai": "^3.3.0",
     "coveralls": "^2.11.4",
+    "deumdify": "^1.2.4",
     "eslint": "^3.18.0",
     "eslint-config-brightspace": "0.2.4",
     "frau-publisher": "^2.6.2",


### PR DESCRIPTION
…node siren parser. This allows the siren parser to exist on the page with UMD FRAs without everything falling apart.