### PR TITLE
Add to json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "browserify:global": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser-global.js",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "npm run lint && npm run test-no-style",
-    "test-no-style": "export NODE_ENV=test; istanbul cover --source-map --dir ./coverage/unit --root src/ node_modules/.bin/_mocha -- --recursive ./test",
+    "test-no-style": "cross-env NODE_ENV=test istanbul cover --source-map --dir ./coverage/unit --root src/ node_modules/mocha/bin/_mocha -- --recursive ./test",
     "posttest": "istanbul report text-summary lcov",
     "report-cov": "istanbul report lcovonly && coveralls < ./coverage/lcov.info",
     "publish:cdn": "frau-publisher"
@@ -43,6 +43,7 @@
     "browserify": "^14.1.0",
     "chai": "^3.3.0",
     "coveralls": "^2.11.4",
+    "cross-env": "^5.0.5",
     "deumdify": "^1.2.4",
     "eslint": "^3.18.0",
     "eslint-config-brightspace": "0.2.4",

--- a/src/Action.js
+++ b/src/Action.js
@@ -71,6 +71,18 @@ function Action(action) {
 	}
 }
 
+Action.prototype.toJSON = function() {
+	return {
+		name: this.name,
+		href: this.href,
+		class: this.class,
+		method: this.method,
+		title: this.title,
+		type: this.type,
+		fields: this.fields
+	};
+};
+
 Action.prototype.hasClass = function(cls) {
 	return this.class instanceof Array && util.contains(this.class, cls);
 };

--- a/src/Action.js
+++ b/src/Action.js
@@ -66,8 +66,6 @@ function Action(action) {
 				});
 			}
 		});
-
-		this.fields = action.fields;
 	}
 }
 

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -155,6 +155,19 @@ function Entity(entity) {
 	}
 }
 
+Entity.prototype.toJSON = function() {
+	return {
+		rel: this.rel,
+		title: this.title,
+		type: this.type,
+		properties: this.properties,
+		class: this.class,
+		actions: this.actions,
+		links: this.links,
+		entities: this.entities
+	};
+};
+
 Entity.prototype.hasAction = function(actionName) {
 	return this.hasActionByName(actionName);
 };

--- a/src/Field.js
+++ b/src/Field.js
@@ -63,6 +63,16 @@ function Field(field) {
 	}
 }
 
+Field.prototype.toJSON = function() {
+	return {
+		name: this.name,
+		class: this.class,
+		type: this.type,
+		value: this.value,
+		title: this.title
+	};
+};
+
 Field.prototype.hasClass = function(cls) {
 	return this.class instanceof Array && util.contains(this.class, cls);
 };

--- a/src/Link.js
+++ b/src/Link.js
@@ -38,6 +38,16 @@ function Link(link) {
 	}
 }
 
+Link.prototype.toJSON = function() {
+	return {
+		rel: this.rel,
+		href: this.href,
+		class: this.class,
+		title: this.title,
+		type: this.type
+	};
+};
+
 Link.prototype.hasClass = function(cls) {
 	return this.class instanceof Array && util.contains(this.class, cls);
 };

--- a/test/action.js
+++ b/test/action.js
@@ -175,6 +175,35 @@ describe('Action', function() {
 		});
 	});
 
+	describe('toJSON', function() {
+		function toJSON() {
+			return JSON.stringify(buildAction());
+		}
+
+		it('should stringify name and href', function() {
+			expect(toJSON()).to.equal(
+				'{"name":"foo","href":"bar","method":"GET","type":"application/x-www-form-urlencoded"}'
+			);
+		});
+
+		it('should stringify class', function() {
+			resource.class = ['abc'];
+			expect(toJSON()).to.equal(
+				'{"name":"foo","href":"bar","class":["abc"],"method":"GET","type":"application/x-www-form-urlencoded"}'
+			);
+		});
+
+		it('should stringify fields', function() {
+			resource.fields = [{
+				name: 'foo',
+				title: 'bar'
+			}];
+			expect(toJSON()).to.equal(
+				'{"name":"foo","href":"bar","method":"GET","type":"application/x-www-form-urlencoded","fields":[{"name":"foo","title":"bar"}]}'
+			);
+		});
+	});
+
 	describe('Helper functions', function() {
 		describe('has...', function() {
 			describe('Class', function() {

--- a/test/action.js
+++ b/test/action.js
@@ -173,6 +173,16 @@ describe('Action', function() {
 			siren = buildAction();
 			expect(siren.getField('foo')).to.have.property('title', 'bar');
 		});
+
+		it('should be able to use field helper methods', function() {
+			resource.fields = [{
+				class: ['abc'],
+				name: 'foo',
+				title: 'bar'
+			}];
+			siren = buildAction();
+			expect(siren.fields[0].hasClass('abc')).to.be.true;
+		});
 	});
 
 	describe('toJSON', function() {

--- a/test/entity.js
+++ b/test/entity.js
@@ -196,6 +196,80 @@ describe('Entity', function() {
 		});
 	});
 
+	describe('toJSON', function() {
+		function toJSON() {
+			return JSON.stringify(buildEntity());
+		}
+
+		it('should stringify (empty)', function() {
+			expect(toJSON()).to.equal(
+				'{}'
+			);
+		});
+
+		it('should stringify title', function() {
+			resource.title = 'A title!';
+			expect(toJSON()).to.equal(
+				'{"title":"A title!"}'
+			);
+		});
+
+		it('should stringify type', function() {
+			resource.type = 'foo';
+			expect(toJSON()).to.equal(
+				'{"type":"foo"}'
+			);
+		});
+
+		it('should stringify properties', function() {
+			resource.properties = {};
+			expect(toJSON()).to.equal(
+				'{"properties":{}}'
+			);
+		});
+
+		it('should stringify class', function() {
+			resource.class = [];
+			expect(toJSON()).to.equal(
+				'{"class":[]}'
+			);
+		});
+
+		it('should stringify actions', function() {
+			resource.actions = [],
+			expect(toJSON()).to.equal(
+				'{"actions":[]}'
+			);
+		});
+
+		it('should stringify links', function() {
+			resource.links = [],
+			expect(toJSON()).to.equal(
+				'{"links":[]}'
+			);
+		});
+
+		it('should stringify entities', function() {
+			resource.entities = [];
+			expect(toJSON()).to.equal(
+				'{"entities":[]}'
+			);
+		});
+
+		it('should stringify sub entities', function() {
+			resource.entities = [{
+				rel: ['foo'],
+				actions: [{
+					name: 'bar',
+					href: 'baz'
+				}]
+			}];
+			expect(toJSON()).to.equal(
+				'{"entities":[{"rel":["foo"],"actions":[{"name":"bar","href":"baz","method":"GET","type":"application/x-www-form-urlencoded"}]}]}'
+			);
+		});
+	});
+
 	describe('helper functions', function() {
 		describe('has...', function() {
 			describe('Action', function() {

--- a/test/field.js
+++ b/test/field.js
@@ -129,4 +129,44 @@ describe('Field', function() {
 			expect(buildField.bind()).to.throw();
 		});
 	});
+
+	describe('toJSON', function() {
+		function toJSON() {
+			return JSON.stringify(buildField());
+		}
+
+		it('should stringify name', function() {
+			expect(toJSON()).to.equal(
+				'{"name":"foo"}'
+			);
+		});
+
+		it('should stringify value', function() {
+			resource.value = 'bar';
+			expect(toJSON()).to.equal(
+				'{"name":"foo","value":"bar"}'
+			);
+		});
+
+		it('should stringify class', function() {
+			resource.class = ['abc'];
+			expect(toJSON()).to.equal(
+				'{"name":"foo","class":["abc"]}'
+			);
+		});
+
+		it('should stringify title', function() {
+			resource.title = 'bar';
+			expect(toJSON()).to.equal(
+				'{"name":"foo","title":"bar"}'
+			);
+		});
+
+		it('should stringify type', function() {
+			resource.type = 'text';
+			expect(toJSON()).to.equal(
+				'{"name":"foo","type":"text"}'
+			);
+		});
+	});
 });

--- a/test/link.js
+++ b/test/link.js
@@ -134,4 +134,37 @@ describe('Link', function() {
 			expect(buildLink.bind(undefined, resource)).to.throw();
 		});
 	});
+
+	describe('toJSON', function() {
+		function toJSON() {
+			return JSON.stringify(buildLink());
+		}
+
+		it('should stringify rel and href', function() {
+			expect(toJSON()).to.equal(
+				'{"rel":[],"href":"foo"}'
+			);
+		});
+
+		it('should stringify class', function() {
+			resource.class = ['abc'];
+			expect(toJSON()).to.equal(
+				'{"rel":[],"href":"foo","class":["abc"]}'
+			);
+		});
+
+		it('should stringify title', function() {
+			resource.title = 'bar';
+			expect(toJSON()).to.equal(
+				'{"rel":[],"href":"foo","title":"bar"}'
+			);
+		});
+
+		it('should stringify type', function() {
+			resource.type = 'text/html';
+			expect(toJSON()).to.equal(
+				'{"rel":[],"href":"foo","type":"text/html"}'
+			);
+		});
+	});
 });


### PR DESCRIPTION
This PR adds `toJSON` methods so that you can use `JSON.stringify(entity)` and get back a Siren entity without any extra underscore properties. I've also fixed a tiny bug I ran into using Field helper methods in items in an Action's `fields` array.

The main use case for this is to recover a vanilla Siren JSON representation to use for message passing without having to keep a reference to the original object or JSON string.