### PR TITLE
Improve error messages to include problem

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -13,19 +13,19 @@ function Action(action) {
 		return new Action(action);
 	}
 
-	assert('object' === typeof action, 'action must be an object');
-	assert('string' === typeof action.name, 'action.name must be a string');
-	assert('string' === typeof action.href, 'action.href must be a string');
+	assert('object' === typeof action, 'action must be an object, got ' + JSON.stringify(action));
+	assert('string' === typeof action.name, 'action.name must be a string, got ' + JSON.stringify(action.name));
+	assert('string' === typeof action.href, 'action.href must be a string, got ' + JSON.stringify(action.href));
 	assert('undefined' === typeof action.class || Array.isArray(action.class),
-		'action.class must be an array or undefined');
+		'action.class must be an array or undefined, got ' + JSON.stringify(action.class));
 	assert('undefined' === typeof action.method || 'string' === typeof action.method,
-		'action.method must be a string or undefined');
+		'action.method must be a string or undefined, got ' + JSON.stringify(action.method));
 	assert('undefined' === typeof action.title || 'string' === typeof action.title,
-		'action.title must be a string or undefined');
+		'action.title must be a string or undefined, got ' + JSON.stringify(action.title));
 	assert('undefined' === typeof action.type || 'string' === typeof action.type,
-		'action.type must be a string or undefined');
+		'action.type must be a string or undefined, got ' + JSON.stringify(action.type));
 	assert('undefined' === typeof action.fields || Array.isArray(action.fields),
-		'action.fields must be an array or undefined');
+		'action.fields must be an array or undefined, got ' + JSON.stringify(action.fields));
 
 	this.name = action.name;
 	this.href = action.href;

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -23,21 +23,21 @@ function Entity(entity) {
 	}
 
 	assert('undefined' === typeof entity.rel || Array.isArray(entity.rel),
-		'entity.rel must be an array or undefined');
+		'entity.rel must be an array or undefined, got ' + JSON.stringify(entity.rel));
 	assert('undefined' === typeof entity.title || 'string' === typeof entity.title,
-		'entity.title must be a string or undefined');
+		'entity.title must be a string or undefined, got ' + JSON.stringify(entity.title));
 	assert('undefined' === typeof entity.type || 'string' === typeof entity.type,
-		'entity.type must be a string or undefined');
+		'entity.type must be a string or undefined, got ' + JSON.stringify(entity.type));
 	assert('undefined' === typeof entity.properties || 'object' === typeof entity.properties,
-		'entity.properties must be an object or undefined');
+		'entity.properties must be an object or undefined, got ' + JSON.stringify(entity.properties));
 	assert('undefined' === typeof entity.class || Array.isArray(entity.class),
-		'entity.class must be an array or undefined');
+		'entity.class must be an array or undefined, got ' + JSON.stringify(entity.class));
 	assert('undefined' === typeof entity.actions || Array.isArray(entity.actions),
-		'entity.actions must be an array or undefined');
+		'entity.actions must be an array or undefined, got ' + JSON.stringify(entity.actions));
 	assert('undefined' === typeof entity.links || Array.isArray(entity.links),
-		'entity.links must be an array or undefined');
+		'entity.links must be an array or undefined, got ' + JSON.stringify(entity.links));
 	assert('undefined' === typeof entity.entities || Array.isArray(entity.entities),
-		'entity.entities must be an array or undefined');
+		'entity.entities must be an array or undefined, got ' + JSON.stringify(entity.entities));
 
 	if (entity.rel) {
 		// Only applies to sub-entities (required for them)
@@ -125,7 +125,8 @@ function Entity(entity) {
 		this.entities = [];
 		entity.entities.forEach(subEntity => {
 			// Subentities must have a rel array
-			assert(Array.isArray(subEntity.rel));
+			assert(Array.isArray(subEntity.rel),
+				'sub-entities must have a rel array, got ' + JSON.stringify(subEntity.rel));
 
 			let subEntityInstance;
 			if ('string' === typeof subEntity.href) {

--- a/src/Field.js
+++ b/src/Field.js
@@ -34,15 +34,15 @@ function Field(field) {
 		return new Field(field);
 	}
 
-	assert('object' === typeof field, 'field must be an object');
-	assert('string' === typeof field.name, 'field.name must be a string');
+	assert('object' === typeof field, 'field must be an object, got ' + JSON.stringify(field));
+	assert('string' === typeof field.name, 'field.name must be a string, got ' + JSON.stringify(field.name));
 	assert('undefined' === typeof field.class || Array.isArray(field.class),
-		'field.class must be an array or undefined');
+		'field.class must be an array or undefined, got ' + JSON.stringify(field.class));
 	assert('undefined' === typeof field.type
 		|| ('string' === typeof field.type && VALID_TYPES.indexOf(field.type.toLowerCase()) > -1),
-		'field.type must be a valid field type string or undefined');
+		'field.type must be a valid field type string or undefined, got ' + JSON.stringify(field.type));
 	assert('undefined' === typeof field.title || 'string' === typeof field.title,
-		'field.title must be a string or undefined');
+		'field.title must be a string or undefined, got ' + JSON.stringify(field.title));
 
 	this.name = field.name;
 

--- a/src/Link.js
+++ b/src/Link.js
@@ -12,15 +12,15 @@ function Link(link) {
 		return new Link(link);
 	}
 
-	assert('object' === typeof link, 'link must be an object');
-	assert(Array.isArray(link.rel), 'link.rel must be an array');
-	assert('string' === typeof link.href, 'link.href must be a string');
+	assert('object' === typeof link, 'link must be an object, got ' + JSON.stringify(link));
+	assert(Array.isArray(link.rel), 'link.rel must be an array, got ' + JSON.stringify(link.rel));
+	assert('string' === typeof link.href, 'link.href must be a string, got ' + JSON.stringify(link.href));
 	assert('undefined' === typeof link.class || Array.isArray(link.class),
-		'link.class must be an array or undefined');
+		'link.class must be an array or undefined, got ' + JSON.stringify(link.class));
 	assert('undefined' === typeof link.title || 'string' === typeof link.title,
-		'link.title must be a string or undefined');
+		'link.title must be a string or undefined, got ' + JSON.stringify(link.title));
 	assert('undefined' === typeof link.type || 'string' === typeof link.type,
-		'link.type must be a string or undefined');
+		'link.type must be a string or undefined, got ' + JSON.stringify(link.type));
 
 	this.rel = link.rel;
 	this.href = link.href;

--- a/test/action.js
+++ b/test/action.js
@@ -46,18 +46,18 @@ describe('Action', function() {
 
 	it('should require the action be an object', function() {
 		resource = 1;
-		expect(buildAction.bind()).to.throw();
+		expect(buildAction.bind()).to.throw('action must be an object, got 1');
 	});
 
 	describe('name', function() {
 		it('should require a name', function() {
 			resource.name = undefined;
-			expect(buildAction.bind()).to.throw();
+			expect(buildAction.bind()).to.throw('action.name must be a string, got undefined');
 		});
 
 		it('should require name be a string', function() {
 			resource.name = 1;
-			expect(buildAction.bind()).to.throw();
+			expect(buildAction.bind()).to.throw('action.name must be a string, got 1');
 		});
 
 		it('should parse name', function() {
@@ -69,12 +69,12 @@ describe('Action', function() {
 	describe('href', function() {
 		it('should require a href', function() {
 			resource.href = undefined;
-			expect(buildAction.bind()).to.throw();
+			expect(buildAction.bind()).to.throw('action.href must be a string, got undefined');
 		});
 
 		it('should require href be a string', function() {
 			resource.href = 1;
-			expect(buildAction.bind()).to.throw();
+			expect(buildAction.bind()).to.throw('action.href must be a string, got 1');
 		});
 
 		it('should parse href', function() {
@@ -92,7 +92,7 @@ describe('Action', function() {
 
 		it('should require class be an array, if supplied', function() {
 			resource.class = 1;
-			expect(buildAction.bind()).to.throw();
+			expect(buildAction.bind()).to.throw('action.class must be an array or undefined, got 1');
 		});
 	});
 
@@ -110,7 +110,7 @@ describe('Action', function() {
 
 		it('should require method be a string, if supplied', function() {
 			resource.method = 1;
-			expect(buildAction.bind(undefined, resource)).to.throw();
+			expect(buildAction.bind(undefined, resource)).to.throw('action.method must be a string or undefined, got 1');
 		});
 	});
 
@@ -123,7 +123,7 @@ describe('Action', function() {
 
 		it('should require title be a string, if supplied', function() {
 			resource.title = 1;
-			expect(buildAction.bind(undefined, resource)).to.throw();
+			expect(buildAction.bind(undefined, resource)).to.throw('action.title must be a string or undefined, got 1');
 		});
 	});
 
@@ -141,7 +141,7 @@ describe('Action', function() {
 
 		it('should require type be a string, if supplied', function() {
 			resource.type = 1;
-			expect(buildAction.bind(undefined, resource)).to.throw();
+			expect(buildAction.bind(undefined, resource)).to.throw('action.type must be a string or undefined, got 1');
 		});
 	});
 
@@ -154,7 +154,7 @@ describe('Action', function() {
 
 		it('should require fields be an array, if supplied', function() {
 			resource.fields = 1;
-			expect(buildAction.bind(undefined, resource)).to.throw();
+			expect(buildAction.bind(undefined, resource)).to.throw('action.fields must be an array or undefined, got 1');
 		});
 
 		it('should be able to determine if an Action has a given Field', function() {

--- a/test/entity.js
+++ b/test/entity.js
@@ -59,7 +59,7 @@ describe('Entity', function() {
 
 		it('should require title be a string, if supplied', function() {
 			resource.title = 1;
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('entity.title must be a string or undefined, got 1');
 		});
 	});
 
@@ -72,7 +72,7 @@ describe('Entity', function() {
 
 		it('should require type be a string, if supplied', function() {
 			resource.type = 1;
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('entity.type must be a string or undefined, got 1');
 		});
 	});
 
@@ -85,7 +85,7 @@ describe('Entity', function() {
 
 		it('should require properties be an object, if supplied', function() {
 			resource.properties = 1;
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('entity.properties must be an object or undefined, got 1');
 		});
 
 		it('should be able to determine if an entity has a given property', function() {
@@ -106,7 +106,7 @@ describe('Entity', function() {
 
 		it('should require class be an array, if supplied', function() {
 			resource.class = 1;
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('entity.class must be an array or undefined, got 1');
 		});
 	});
 
@@ -119,7 +119,7 @@ describe('Entity', function() {
 
 		it('should require actions be an array, if supplied', function() {
 			resource.actions = 1;
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('entity.actions must be an array or undefined, got 1');
 		});
 	});
 
@@ -132,7 +132,7 @@ describe('Entity', function() {
 
 		it('should require links be an array, if supplied', function() {
 			resource.links = 1;
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('entity.links must be an array or undefined, got 1');
 		});
 	});
 
@@ -145,14 +145,14 @@ describe('Entity', function() {
 
 		it('should require (sub)entities be an array, if supplied', function() {
 			resource.entities = 1;
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('entity.entities must be an array or undefined, got 1');
 		});
 
 		it('should require (sub)entities have a rel', function() {
 			resource.entities = [{
 				foo: 'bar'
 			}];
-			expect(buildEntity.bind()).to.throw();
+			expect(buildEntity.bind()).to.throw('sub-entities must have a rel array, got undefined');
 		});
 
 		it('should work with chained Entity/Action/Links', function() {

--- a/test/field.js
+++ b/test/field.js
@@ -45,18 +45,18 @@ describe('Field', function() {
 
 	it('should require the field be an object', function() {
 		resource = 1;
-		expect(buildField.bind()).to.throw();
+		expect(buildField.bind()).to.throw('field must be an object, got 1');
 	});
 
 	describe('name', function() {
 		it('should require a name', function() {
 			resource.name = undefined;
-			expect(buildField.bind()).to.throw();
+			expect(buildField.bind()).to.throw('field.name must be a string, got undefined');
 		});
 
 		it('should require name be a string', function() {
 			resource.name = 1;
-			expect(buildField.bind()).to.throw();
+			expect(buildField.bind()).to.throw('field.name must be a string, got 1');
 		});
 
 		it('should parse name', function() {
@@ -82,7 +82,7 @@ describe('Field', function() {
 
 		it('should require class be an array, if supplied', function() {
 			resource.class = 1;
-			expect(buildField.bind()).to.throw();
+			expect(buildField.bind()).to.throw('field.class must be an array or undefined, got 1');
 		});
 
 		it('should be able to determine if a field has a given class', function() {
@@ -108,7 +108,7 @@ describe('Field', function() {
 
 		it('should require title be a string, if supplied', function() {
 			resource.title = 1;
-			expect(buildField.bind(undefined, resource)).to.throw();
+			expect(buildField.bind(undefined, resource)).to.throw('field.title must be a string or undefined, got 1');
 		});
 	});
 
@@ -121,12 +121,12 @@ describe('Field', function() {
 
 		it('should require type be a string, if supplied', function() {
 			resource.type = 1;
-			expect(buildField.bind(undefined, resource)).to.throw();
+			expect(buildField.bind(undefined, resource)).to.throw('field.type must be a valid field type string or undefined, got 1');
 		});
 
 		it('should require type be a valid HTML5 input type, if specified', function() {
 			resource.type = 'bar';
-			expect(buildField.bind()).to.throw();
+			expect(buildField.bind()).to.throw('field.type must be a valid field type string or undefined, got "bar"');
 		});
 	});
 });

--- a/test/link.js
+++ b/test/link.js
@@ -46,18 +46,18 @@ describe('Link', function() {
 
 	it('should require the link be an object', function() {
 		resource = 1;
-		expect(buildLink.bind()).to.throw();
+		expect(buildLink.bind()).to.throw('link must be an object, got 1');
 	});
 
 	describe('rel', function() {
 		it('should require a rel', function() {
 			resource.rel = undefined;
-			expect(buildLink.bind()).to.throw();
+			expect(buildLink.bind()).to.throw('link.rel must be an array, got undefined');
 		});
 
 		it('should require rel be an array', function() {
 			resource.rel = 1;
-			expect(buildLink.bind()).to.throw();
+			expect(buildLink.bind()).to.throw('link.rel must be an array, got 1');
 		});
 
 		it('should parse rel', function() {
@@ -69,12 +69,12 @@ describe('Link', function() {
 	describe('href', function() {
 		it('should require a href', function() {
 			resource.href = undefined;
-			expect(buildLink.bind()).to.throw();
+			expect(buildLink.bind()).to.throw('link.href must be a string, got undefined');
 		});
 
 		it('should require href be a string', function() {
 			resource.href = 1;
-			expect(buildLink.bind()).to.throw();
+			expect(buildLink.bind()).to.throw('link.href must be a string, got 1');
 		});
 
 		it('should parse href', function() {
@@ -92,7 +92,7 @@ describe('Link', function() {
 
 		it('should require class be an array, if supplied', function() {
 			resource.class = 1;
-			expect(buildLink.bind()).to.throw();
+			expect(buildLink.bind()).to.throw('link.class must be an array or undefined, got 1');
 		});
 
 		it('should be able to determine if a link has a given class', function() {
@@ -118,7 +118,7 @@ describe('Link', function() {
 
 		it('should require title be a string, if supplied', function() {
 			resource.title = 1;
-			expect(buildLink.bind(undefined, resource)).to.throw();
+			expect(buildLink.bind(undefined, resource)).to.throw('link.title must be a string or undefined, got 1');
 		});
 	});
 
@@ -131,7 +131,7 @@ describe('Link', function() {
 
 		it('should require type be a string, if supplied', function() {
 			resource.type = 1;
-			expect(buildLink.bind(undefined, resource)).to.throw();
+			expect(buildLink.bind(undefined, resource)).to.throw('link.type must be a string or undefined, got 1');
 		});
 	});
 });


### PR DESCRIPTION
It has happened a few times now that a Siren object defined in a test is missing a required attribute, or it is of the wrong type, but without specifying more information, it was often difficult to track down these mistakes. This adds a little more information, although in the case where something is missing it just says "got undefined", which is perhaps of dubious value but at least it makes it abundantly clear what exactly is wrong.

Contrived example - before:

![before](https://user-images.githubusercontent.com/6231623/33283528-1befbb52-d37a-11e7-83f5-d532ac89464a.png)

after:

![after](https://user-images.githubusercontent.com/6231623/33283527-1bce68bc-d37a-11e7-9232-8fbf869f8723.png)

Not a tonne of extra information, but hopefully useful for finding where the error is coming from.