### PR TITLE
Skip cleanup on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ after_success:
 - npm run browserify
 - '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && [ "x$TRAVIS_TAG" != "x" ] && npm run publish:cdn'
 deploy:
+  # Travis will remove the dist/ folder before deploy if we don't include this
+  skip_cleanup: true
   provider: npm
   email: d2ltravisdeploy@d2l.com
   api_key:


### PR DESCRIPTION
Recent releases have not included the dist/ folder in the npm package. This appears to be because Travis does a cleanup after build, before running the deployment, which is removing this folder. In order to include it, use skip_cleanup.