### PR TITLE
Add functions for getting by an array of classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,22 @@ resource.getSubEntitiesByClass('inner'); // [ All Entities with 'inner' class ]
 Returns the resource(s) of type _X_ with matching _Y_ values of multiple `key` (or which matches `RegExp key`). The requested _X_ must contain each of the _Y_ values. If the requested _X_ is singular, then the result is either the matching instance of _X_, or undefined. If the requested _X_ is plural, then the result is either an Array of the matching instances of _X_, or an empty Array.
 
 * `getActionByClasses(classes)` - returns [Action](#action) or undefined
+* `getActionsByClasses(classes)` - returns Array of [Action](#action) (empty Array if none match)
+* `getFieldByClasses(classes)` - returns [Field](#field) or undefined
+* `getFieldsByClasses(classes)` - returns Array of [Field](#field) (empty Array if none match)
 * `getLinkByClasses(class)` - returns [Link](#link) or undefined
-
+* `getLinksByClasses(class)` - return Array of [Link](#link) (empty Array if none match)
+* `getSubEntityByClasses(classes)` - returns [Entity](#entity) or undefined
+* `getSubEntitiesByClasses(classes)` - returns Array of [Entity](#entity) (empty Array if none match)
 ```js
-resource.getLinkBySomeClasses(['crazy', 'self']) // A link instance that contains both 'self' and 'crazy' classes.
-resource.getLinksBySomeClasses(['crazy', 'cool']) // Array containing two links, both of which contain both 'crazy' and 'cool' classes. Note that a link containing only one of those will not be included in the array.
+resource.getActionByClasses(['crazy', 'self']) // An action instance that contains both 'self' and 'crazy' classes.
+resource.getActionsByClasses(['crazy', 'cool']) // Array containing two actions, both of which contain both 'crazy' and 'cool' classes. Note that an action containing only one of those will not be included in the array.
+resource.getFieldByClasses(['crazy', 'self']) // A field instance that contains both 'self' and 'crazy' classes.
+resource.getFieldsByClasses(['crazy', 'cool']) // Array containing two fields, both of which contain both 'crazy' and 'cool' classes. Note that a field containing only one of those will not be included in the array.
+resource.getLinkByClasses(['crazy', 'self']) // A link instance that contains both 'self' and 'crazy' classes.
+resource.getLinksByClasses(['crazy', 'cool']) // Array containing two links, both of which contain both 'crazy' and 'cool' classes. Note that a link containing only one of those will not be included in the array.
+resource.getSubEntityByClasses(['crazy', 'self']) // Am entity instance that contains both 'self' and 'crazy' classes.
+resource.getSubEntitiesByClasses(['crazy', 'cool']) // Array containing two entities, both of which contain both 'crazy' and 'cool' classes. Note that an entity containing only one of those will not be included in the array.
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -192,8 +192,12 @@ Returns the resource(s) of type _X_ with matching _Y_ values of multiple `key` (
 * `getFieldsByClasses(classes)` - returns Array of [Field](#field) (empty Array if none match)
 * `getLinkByClasses(class)` - returns [Link](#link) or undefined
 * `getLinksByClasses(class)` - return Array of [Link](#link) (empty Array if none match)
+* `getLinkByRels(class)` - returns [Link](#link) or undefined
+* `getLinksByRels(class)` - return Array of [Link](#link) (empty Array if none match)
 * `getSubEntityByClasses(classes)` - returns [Entity](#entity) or undefined
 * `getSubEntitiesByClasses(classes)` - returns Array of [Entity](#entity) (empty Array if none match)
+* `getSubEntityByRels(classes)` - returns [Entity](#entity) or undefined
+* `getSubEntitiesByRels(classes)` - returns Array of [Entity](#entity) (empty Array if none match)
 ```js
 resource.getActionByClasses(['crazy', 'self']) // An action instance that contains both 'self' and 'crazy' classes.
 resource.getActionsByClasses(['crazy', 'cool']) // Array containing two actions, both of which contain both 'crazy' and 'cool' classes. Note that an action containing only one of those will not be included in the array.
@@ -201,8 +205,12 @@ resource.getFieldByClasses(['crazy', 'self']) // A field instance that contains 
 resource.getFieldsByClasses(['crazy', 'cool']) // Array containing two fields, both of which contain both 'crazy' and 'cool' classes. Note that a field containing only one of those will not be included in the array.
 resource.getLinkByClasses(['crazy', 'self']) // A link instance that contains both 'self' and 'crazy' classes.
 resource.getLinksByClasses(['crazy', 'cool']) // Array containing two links, both of which contain both 'crazy' and 'cool' classes. Note that a link containing only one of those will not be included in the array.
-resource.getSubEntityByClasses(['crazy', 'self']) // Am entity instance that contains both 'self' and 'crazy' classes.
+resource.getLinkByRels(['thing1', 'thing2']) // A link instance that contains both 'thing1' and 'thing2' rels.
+resource.getLinksByRels(['thing1', 'thing2']) // Array containing two links, both of which contain both 'thing1' and 'thing2' rels. Note that a link containing only one of those will not be included in the array.
+resource.getSubEntityByClasses(['crazy', 'self']) // An entity instance that contains both 'self' and 'crazy' classes.
 resource.getSubEntitiesByClasses(['crazy', 'cool']) // Array containing two entities, both of which contain both 'crazy' and 'cool' classes. Note that an entity containing only one of those will not be included in the array.
+resource.getSubEntityByRels(['thing1', 'thing2']) // An entity instance that contains both 'thing1' and 'thing2' rels.
+resource.getSubEntitiesByRels(['thing1', 'thing2']) // Array containing two entities, both of which contain both 'thing1' and 'thing2' rels. Note that an entity containing only one of those will not be included in the array.
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Parses a Siren object (or Siren JSON string) into an Entity object that is inten
 
 ## Usage
 
-There are two ways to use `node-siren-parser`'s functionality. 
+There are two ways to use `node-siren-parser`'s functionality.
 
 1. You can install it from npm using
    ```bash
    npm install siren-parser
    ```
-   and then `require` it as you would any other npm package. 
+   and then `require` it as you would any other npm package.
 
 2. The parser is browserified and stored on the Brightspace CDN for client-side usage
    ```html
    <script src="https://s.brightspace.com/lib/siren-parser/{version}/siren-parser.js"></script>
-   
+
    <script>
    var parsedEntity = window.D2L.Hypermedia.Siren.Parse('{"class":["foo","bar"]}');
    </script>
@@ -181,6 +181,17 @@ resource.getSubEntityByRel('child'); // Single entity
 resource.getSubEntityByRel('child').getLink('self').title; // 'Child entity'
 resource.getSubEntityByClass('inner'); // Entity with 'inner' class
 resource.getSubEntitiesByClass('inner'); // [ All Entities with 'inner' class ]
+```
+
+#### `Entity.getXByY'es(Array[String|RegExp key])`
+Returns the resource(s) of type _X_ with matching _Y_ values of multiple `key` (or which matches `RegExp key`). The requested _X_ must contain each of the _Y_ values. If the requested _X_ is singular, then the result is either the matching instance of _X_, or undefined. If the requested _X_ is plural, then the result is either an Array of the matching instances of _X_, or an empty Array.
+
+* `getActionByClasses(classes)` - returns [Action](#action) or undefined
+* `getLinkByClasses(class)` - returns [Link](#link) or undefined
+
+```js
+resource.getLinkBySomeClasses(['crazy', 'self']) // A link instance that contains both 'self' and 'crazy' classes.
+resource.getLinksBySomeClasses(['crazy', 'cool']) // Array containing two links, both of which contain both 'crazy' and 'cool' classes. Note that a link containing only one of those will not be included in the array.
 ```
 
 ---

--- a/src/Action.js
+++ b/src/Action.js
@@ -109,6 +109,16 @@ Action.prototype.getFieldsByClass = function(fieldClass) {
 	return vals ? vals.slice() : [];
 };
 
+Action.prototype.getFieldByClasses = function(fieldClasses) {
+	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses);
+	return vals && vals.length > 0 ? vals[0] : undefined;
+};
+
+Action.prototype.getFieldsByClasses = function(fieldClasses) {
+	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses);
+	return vals && vals.length > 0 ? vals.slice() : [];
+};
+
 Action.prototype.getFieldByType = function(fieldType) {
 	const vals = util.getMatchingValue(this._fieldsByType, fieldType);
 	return vals ? vals[0] : undefined;

--- a/src/Action.js
+++ b/src/Action.js
@@ -110,12 +110,12 @@ Action.prototype.getFieldsByClass = function(fieldClass) {
 };
 
 Action.prototype.getFieldByClasses = function(fieldClasses) {
-	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses);
+	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Action.prototype.getFieldsByClasses = function(fieldClasses) {
-	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses);
+	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -246,6 +246,16 @@ Entity.prototype.getActionsByClass = function(actionClass) {
 	return vals ? vals.slice() : [];
 };
 
+Entity.prototype.getActionByClasses = function(actionClasses) {
+	const vals = util.getMatchingValuesByAll(this.actions, actionClasses);
+	return vals && vals.length > 0 ? vals[0] : undefined;
+};
+
+Entity.prototype.getActionsByClasses = function(actionClasses) {
+	const vals = util.getMatchingValuesByAll(this.actions, actionClasses);
+	return vals && vals.length > 0 ? vals.slice() : [];
+};
+
 Entity.prototype.getActionByMethod = function(actionMethod) {
 	const vals = util.getMatchingValue(this._actionsByMethod, actionMethod);
 	return vals ? vals[0] : undefined;
@@ -294,6 +304,16 @@ Entity.prototype.getLinksByClass = function(linkClass) {
 	return vals ? vals.slice() : [];
 };
 
+Entity.prototype.getLinkByClasses = function(linkClasses) {
+	const vals = util.getMatchingValuesByAll(this.links, linkClasses);
+	return vals && vals.length > 0 ? vals[0] : undefined;
+};
+
+Entity.prototype.getLinksByClasses = function(linkClasses) {
+	const vals = util.getMatchingValuesByAll(this.links, linkClasses);
+	return vals && vals.length > 0 ? vals.slice() : [];
+};
+
 Entity.prototype.getLinkByType = function(linkType) {
 	const vals = util.getMatchingValue(this._linksByType, linkType);
 	return vals ? vals[0] : undefined;
@@ -330,6 +350,16 @@ Entity.prototype.getSubEntityByClass = function(entityClass) {
 Entity.prototype.getSubEntitiesByClass = function(entityClass) {
 	const vals = util.getMatchingValue(this._entitiesByClass, entityClass);
 	return vals ? vals.slice() : [];
+};
+
+Entity.prototype.getSubEntityByClasses = function(entityClasses) {
+	const vals = util.getMatchingValuesByAll(this.entities, entityClasses);
+	return vals && vals.length > 0 ? vals[0] : undefined;
+};
+
+Entity.prototype.getSubEntitiesByClasses = function(entityClasses) {
+	const vals = util.getMatchingValuesByAll(this.entities, entityClasses);
+	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
 Entity.prototype.getSubEntityByType = function(entityType) {

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -247,12 +247,12 @@ Entity.prototype.getActionsByClass = function(actionClass) {
 };
 
 Entity.prototype.getActionByClasses = function(actionClasses) {
-	const vals = util.getMatchingValuesByAll(this.actions, actionClasses);
+	const vals = util.getMatchingValuesByAll(this.actions, actionClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByClasses = function(actionClasses) {
-	const vals = util.getMatchingValuesByAll(this.actions, actionClasses);
+	const vals = util.getMatchingValuesByAll(this.actions, actionClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
@@ -294,6 +294,16 @@ Entity.prototype.getLinksByRel = function(linkRel) {
 	return vals ? vals.slice() : [];
 };
 
+Entity.prototype.getLinkByRels = function(linkRels) {
+	const vals = util.getMatchingValuesByAll(this.links, linkRels, 'rel');
+	return vals && vals.length > 0 ? vals[0] : undefined;
+};
+
+Entity.prototype.getLinksByRels = function(linkRels) {
+	const vals = util.getMatchingValuesByAll(this.links, linkRels, 'rel');
+	return vals && vals.length > 0 ? vals.slice() : [];
+};
+
 Entity.prototype.getLinkByClass = function(linkClass) {
 	const vals = util.getMatchingValue(this._linksByClass, linkClass);
 	return vals ? vals[0] : undefined;
@@ -305,12 +315,12 @@ Entity.prototype.getLinksByClass = function(linkClass) {
 };
 
 Entity.prototype.getLinkByClasses = function(linkClasses) {
-	const vals = util.getMatchingValuesByAll(this.links, linkClasses);
+	const vals = util.getMatchingValuesByAll(this.links, linkClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByClasses = function(linkClasses) {
-	const vals = util.getMatchingValuesByAll(this.links, linkClasses);
+	const vals = util.getMatchingValuesByAll(this.links, linkClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
@@ -342,6 +352,16 @@ Entity.prototype.getSubEntitiesByRel = function(entityRel) {
 	return vals ? vals.slice() : [];
 };
 
+Entity.prototype.getSubEntityByRels = function(entityRels) {
+	const vals = util.getMatchingValuesByAll(this.entities, entityRels, 'rel');
+	return vals && vals.length > 0 ? vals[0] : undefined;
+};
+
+Entity.prototype.getSubEntitiesByRels = function(entityRels) {
+	const vals = util.getMatchingValuesByAll(this.entities, entityRels, 'rel');
+	return vals && vals.length > 0 ? vals.slice() : [];
+};
+
 Entity.prototype.getSubEntityByClass = function(entityClass) {
 	const vals = util.getMatchingValue(this._entitiesByClass, entityClass);
 	return vals ? vals[0] : undefined;
@@ -353,12 +373,12 @@ Entity.prototype.getSubEntitiesByClass = function(entityClass) {
 };
 
 Entity.prototype.getSubEntityByClasses = function(entityClasses) {
-	const vals = util.getMatchingValuesByAll(this.entities, entityClasses);
+	const vals = util.getMatchingValuesByAll(this.entities, entityClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getSubEntitiesByClasses = function(entityClasses) {
-	const vals = util.getMatchingValuesByAll(this.entities, entityClasses);
+	const vals = util.getMatchingValuesByAll(this.entities, entityClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -35,8 +35,26 @@ function getMatchingValue(objectLike, stringOrRegex) {
 	}
 }
 
+function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex) {
+	if (!Array.isArray(arrayOfStringOrRegex)) {
+		return [];
+	}
+
+	const vals = [];
+	for (var i = 0; i < arrayLike.length; i++) {
+		var like = arrayLike[i];
+
+		if (arrayOfStringOrRegex.every((cls) => { return contains(like.class, cls); })) {
+			vals.push(like);
+		}
+	}
+
+	return vals;
+}
+
 module.exports = {
 	contains: contains,
 	hasProperty: hasProperty,
-	getMatchingValue: getMatchingValue
+	getMatchingValue: getMatchingValue,
+	getMatchingValuesByAll: getMatchingValuesByAll
 };

--- a/src/util.js
+++ b/src/util.js
@@ -44,7 +44,11 @@ function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex) {
 	for (var i = 0; i < arrayLike.length; i++) {
 		var like = arrayLike[i];
 
-		if (arrayOfStringOrRegex.every((cls) => { return contains(like.class, cls); })) {
+		if (arrayOfStringOrRegex.every(
+			function(cls) {
+				return contains(like.class, cls);
+			})
+		) {
 			vals.push(like);
 		}
 	}

--- a/src/util.js
+++ b/src/util.js
@@ -35,8 +35,8 @@ function getMatchingValue(objectLike, stringOrRegex) {
 	}
 }
 
-function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex) {
-	if (!Array.isArray(arrayOfStringOrRegex)) {
+function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex, propertyToMatch) {
+	if (!Array.isArray(arrayOfStringOrRegex) || !propertyToMatch) {
 		return [];
 	}
 
@@ -45,8 +45,8 @@ function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex) {
 		var like = arrayLike[i];
 
 		if (arrayOfStringOrRegex.every(
-			function(cls) {
-				return contains(like.class, cls);
+			function(y) {
+				return contains(like[propertyToMatch], y);
 			})
 		) {
 			vals.push(like);

--- a/test/action.js
+++ b/test/action.js
@@ -296,15 +296,19 @@ describe('Action', function() {
 				it('getFieldByClasses', function() {
 					expect(siren.getFieldByClasses(['bonk', 'bork'])).to.have.property('name', 'foo3');
 					expect(siren.getFieldByClasses([/bonk/, /bork/])).to.have.property('name', 'foo3');
+					expect(siren.getFieldByClasses(['bonk', /bork/])).to.have.property('name', 'foo3');
 					expect(siren.getFieldByClasses(['bonk', 'nope'])).to.be.undefined;
 					expect(siren.getFieldByClasses([/bonk/, /nope/])).to.be.undefined;
+					expect(siren.getFieldByClasses(['bonk', /nope/])).to.be.undefined;
 				});
 
 				it('getFieldsByClasses', function() {
 					expect(siren.getFieldsByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getFieldsByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getFieldsByClasses(['bonk', /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getFieldsByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
 					expect(siren.getFieldsByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getFieldsByClasses(['bonk', /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getFieldByType', function() {

--- a/test/action.js
+++ b/test/action.js
@@ -248,13 +248,23 @@ describe('Action', function() {
 					resource.fields = [{
 						name: 'foo',
 						title: 'bar',
-						class: ['baz'],
+						class: ['baz', 'bonk'],
 						type: 'text'
 					}, {
 						name: 'foo2',
 						title: 'bar2',
-						class: ['baz'],
+						class: ['baz', 'bork'],
 						type: 'text'
+					}, {
+						name: 'foo3',
+						title: 'bar3',
+						class: ['bonk', 'bork'],
+						type: 'url'
+					}, {
+						name: 'foo4',
+						title: 'bar4',
+						class: ['bonk', 'bork'],
+						type: 'url'
 					}];
 					siren = buildAction();
 				});
@@ -281,6 +291,20 @@ describe('Action', function() {
 
 					expect(siren.getFieldsByClass(/baz/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getFieldsByClass(/foo/)).to.be.an.instanceof(Array).and.to.be.empty;
+				});
+
+				it('getFieldByClasses', function() {
+					expect(siren.getFieldByClasses(['bonk', 'bork'])).to.have.property('name', 'foo3');
+					expect(siren.getFieldByClasses([/bonk/, /bork/])).to.have.property('name', 'foo3');
+					expect(siren.getFieldByClasses(['bonk', 'nope'])).to.be.undefined;
+					expect(siren.getFieldByClasses([/bonk/, /nope/])).to.be.undefined;
+				});
+
+				it('getFieldsByClasses', function() {
+					expect(siren.getFieldsByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getFieldsByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getFieldsByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getFieldsByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getFieldByType', function() {

--- a/test/entity.js
+++ b/test/entity.js
@@ -458,6 +458,56 @@ describe('Entity', function() {
 					expect(siren.getActionsByClass(/foo/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
+				it('getActionByClasses', function() {
+					resource.actions = [{
+						name: 'foo',
+						href: 'bar',
+						class: ['baz', 'bonk']
+					}, {
+						name: 'foo2',
+						href: 'bar2',
+						class: ['baz', 'bork']
+					}, {
+						name: 'foo3',
+						href: 'bar3',
+						class: ['bork', 'bonk']
+					}, {
+						name: 'foo4',
+						href: 'bar4',
+						class: ['bork', 'bonk']
+					}];
+					siren = buildEntity();
+					expect(siren.getActionByClasses(['bonk', 'bork'])).to.have.property('href', 'bar3');
+					expect(siren.getActionByClasses([/bonk/, /bork/])).to.have.property('href', 'bar3');
+					expect(siren.getActionByClasses(['bonk', 'nope'])).to.be.undefined;
+					expect(siren.getActionByClasses([/bonk/, /nope/])).to.be.undefined;
+				});
+
+				it('getActionsByClasses', function() {
+					resource.actions = [{
+						name: 'foo',
+						href: 'bar',
+						class: ['baz', 'bonk']
+					}, {
+						name: 'foo2',
+						href: 'bar2',
+						class: ['baz', 'bork']
+					}, {
+						name: 'foo3',
+						href: 'bar3',
+						class: ['bork', 'bonk']
+					}, {
+						name: 'foo4',
+						href: 'bar4',
+						class: ['bork', 'bonk']
+					}];
+					siren = buildEntity();
+					expect(siren.getActionsByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getActionsByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getActionsByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getActionsByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+				});
+
 				it('getActionByMethod', function() {
 					resource.actions = [{
 						name: 'foo',
@@ -524,13 +574,23 @@ describe('Entity', function() {
 					resource.links = [{
 						rel: ['foo'],
 						href: 'bar',
-						class: ['baz'],
+						class: ['baz', 'bonk'],
 						type: 'quux'
 					}, {
 						rel: ['foo', 'foo2'],
 						href: 'bar2',
-						class: ['baz'],
+						class: ['baz', 'bork'],
 						type: 'quux'
+					}, {
+						rel: ['foo3'],
+						href: 'bar3',
+						class: ['bork', 'bonk'],
+						type: 'xxuq'
+					}, {
+						rel: ['foo4'],
+						href: 'bar4',
+						class: ['bork', 'bonk'],
+						type: 'xxuq'
 					}];
 					siren = buildEntity();
 				});
@@ -568,6 +628,20 @@ describe('Entity', function() {
 					expect(siren.getLinksByClass(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
+				it('getLinkByClasses', function() {
+					expect(siren.getLinkByClasses(['bonk', 'bork'])).to.have.property('href', 'bar3');
+					expect(siren.getLinkByClasses([/bonk/, /bork/])).to.have.property('href', 'bar3');
+					expect(siren.getLinkByClasses(['bonk', 'nope'])).to.be.undefined;
+					expect(siren.getLinkByClasses([/bonk/, /nope/])).to.be.undefined;
+				});
+
+				it('getLinksByClasses', function() {
+					expect(siren.getLinksByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getLinksByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getLinksByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getLinksByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+				});
+
 				it('getLinkByType', function() {
 					expect(siren.getLinkByType('quux')).to.have.property('href', 'bar');
 					expect(siren.getLinkByType(/quux/)).to.have.property('href', 'bar');
@@ -588,13 +662,23 @@ describe('Entity', function() {
 					resource.entities = [{
 						rel: ['foo'],
 						title: 'bar',
-						class: ['baz'],
+						class: ['baz', 'bonk'],
 						type: 'quux'
 					}, {
 						rel: ['foo', 'foo2'],
 						title: 'bar2',
-						class: ['baz'],
+						class: ['baz', 'bork'],
 						type: 'quux'
+					}, {
+						rel: ['foo3'],
+						title: 'bar3',
+						class: ['bork', 'bonk'],
+						type: 'xxuq'
+					}, {
+						rel: ['foo4'],
+						title: 'bar4',
+						class: ['bork', 'bonk'],
+						type: 'xxuq'
 					}];
 					siren = buildEntity();
 				});
@@ -630,6 +714,20 @@ describe('Entity', function() {
 					expect(siren.getSubEntitiesByClass(/baz/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getSubEntitiesByClass('nope')).to.be.an.instanceof(Array).and.to.be.empty;
 					expect(siren.getSubEntitiesByClass(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
+				});
+
+				it('getSubEntityByClasses', function() {
+					expect(siren.getSubEntityByClasses(['bonk', 'bork'])).to.have.property('title', 'bar3');
+					expect(siren.getSubEntityByClasses([/bonk/, /bork/])).to.have.property('title', 'bar3');
+					expect(siren.getSubEntityByClasses(['bonk', 'nope'])).to.be.undefined;
+					expect(siren.getSubEntityByClasses([/bonk/, /nope/])).to.be.undefined;
+				});
+
+				it('getSubEntitiesByClasses', function() {
+					expect(siren.getSubEntitiesByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getSubEntitiesByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getSubEntitiesByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getSubEntitiesByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getSubEntityByType', function() {

--- a/test/entity.js
+++ b/test/entity.js
@@ -613,6 +613,24 @@ describe('Entity', function() {
 					expect(siren.getLinks(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
+				it('getLinkByRels)', function() {
+					expect(siren.getLinkByRels(['foo', 'foo2'])).to.have.property('href', 'bar2');
+					expect(siren.getLinkByRels([/foo/, /foo2/])).to.have.property('href', 'bar2');
+					expect(siren.getLinkByRels(['foo', /foo2/])).to.have.property('href', 'bar2');
+					expect(siren.getLinkByRels(['foo', 'nope'])).to.be.undefined;
+					expect(siren.getLinkByRels([/foo/, /nope/])).to.be.undefined;
+					expect(siren.getLinkByRels(['foo', /nope/])).to.be.undefined;
+				});
+
+				it('getLinksByRels', function() {
+					expect(siren.getLinksByRels(['foo', 'foo2'])).to.be.an.instanceof(Array).with.lengthOf(1);
+					expect(siren.getLinksByRels([/foo/, /foo2/])).to.be.an.instanceof(Array).with.lengthOf(1);
+					expect(siren.getLinksByRels(['foo', /foo2/])).to.be.an.instanceof(Array).with.lengthOf(1);
+					expect(siren.getLinksByRels(['foo', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getLinksByRels([/foo/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getLinksByRels(['foo', /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+				});
+
 				it('getLinks should return a new array', function() {
 					expect(siren.getLinks('foo')).to.not.equal(siren.getLinks('foo'));
 					expect(siren.getLinks(/foo/)).to.not.equal(siren.getLinks('foo'));
@@ -703,6 +721,24 @@ describe('Entity', function() {
 					expect(siren.getSubEntities(/foo/)).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getSubEntities('nope')).to.be.an.instanceof(Array).and.to.be.empty;
 					expect(siren.getSubEntities(/nope/)).to.be.an.instanceof(Array).and.to.be.empty;
+				});
+
+				it('getSubEntityByRels', function() {
+					expect(siren.getSubEntityByRels(['foo', 'foo2'])).to.have.property('title', 'bar2');
+					expect(siren.getSubEntityByRels([/foo/, /foo2/])).to.have.property('title', 'bar2');
+					expect(siren.getSubEntityByRels(['foo', /foo2/])).to.have.property('title', 'bar2');
+					expect(siren.getSubEntityByRels(['foo', 'nope'])).to.be.undefined;
+					expect(siren.getSubEntityByRels([/foo/, /nope/])).to.be.undefined;
+					expect(siren.getSubEntityByRels(['foo', /nope/])).to.be.undefined;
+				});
+
+				it('getSubEntitiesByRels', function() {
+					expect(siren.getSubEntitiesByRels(['foo', 'foo2'])).to.be.an.instanceof(Array).with.lengthOf(1);
+					expect(siren.getSubEntitiesByRels([/foo/, /foo2/])).to.be.an.instanceof(Array).with.lengthOf(1);
+					expect(siren.getSubEntitiesByRels(['foo', /foo2/])).to.be.an.instanceof(Array).with.lengthOf(1);
+					expect(siren.getSubEntitiesByRels(['foo', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getSubEntitiesByRels([/foo/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getSubEntitiesByRels(['foo', /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getSubEntities should return a new array', function() {

--- a/test/entity.js
+++ b/test/entity.js
@@ -479,8 +479,10 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.getActionByClasses(['bonk', 'bork'])).to.have.property('href', 'bar3');
 					expect(siren.getActionByClasses([/bonk/, /bork/])).to.have.property('href', 'bar3');
+					expect(siren.getActionByClasses(['bonk', /bork/])).to.have.property('href', 'bar3');
 					expect(siren.getActionByClasses(['bonk', 'nope'])).to.be.undefined;
 					expect(siren.getActionByClasses([/bonk/, /nope/])).to.be.undefined;
+					expect(siren.getActionByClasses(['bonk', /nope/])).to.be.undefined;
 				});
 
 				it('getActionsByClasses', function() {
@@ -504,8 +506,10 @@ describe('Entity', function() {
 					siren = buildEntity();
 					expect(siren.getActionsByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getActionsByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getActionsByClasses(['bonk', /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getActionsByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
 					expect(siren.getActionsByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getActionsByClasses(['bonk', /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getActionByMethod', function() {
@@ -631,15 +635,19 @@ describe('Entity', function() {
 				it('getLinkByClasses', function() {
 					expect(siren.getLinkByClasses(['bonk', 'bork'])).to.have.property('href', 'bar3');
 					expect(siren.getLinkByClasses([/bonk/, /bork/])).to.have.property('href', 'bar3');
+					expect(siren.getLinkByClasses(['bonk', /bork/])).to.have.property('href', 'bar3');
 					expect(siren.getLinkByClasses(['bonk', 'nope'])).to.be.undefined;
 					expect(siren.getLinkByClasses([/bonk/, /nope/])).to.be.undefined;
+					expect(siren.getLinkByClasses(['bonk', /nope/])).to.be.undefined;
 				});
 
 				it('getLinksByClasses', function() {
 					expect(siren.getLinksByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getLinksByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getLinksByClasses(['bonk', /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getLinksByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
 					expect(siren.getLinksByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getLinksByClasses(['bonk', /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getLinkByType', function() {
@@ -719,15 +727,19 @@ describe('Entity', function() {
 				it('getSubEntityByClasses', function() {
 					expect(siren.getSubEntityByClasses(['bonk', 'bork'])).to.have.property('title', 'bar3');
 					expect(siren.getSubEntityByClasses([/bonk/, /bork/])).to.have.property('title', 'bar3');
+					expect(siren.getSubEntityByClasses(['bonk', /bork/])).to.have.property('title', 'bar3');
 					expect(siren.getSubEntityByClasses(['bonk', 'nope'])).to.be.undefined;
 					expect(siren.getSubEntityByClasses([/bonk/, /nope/])).to.be.undefined;
+					expect(siren.getSubEntityByClasses(['bonk', /nope/])).to.be.undefined;
 				});
 
 				it('getSubEntitiesByClasses', function() {
 					expect(siren.getSubEntitiesByClasses(['bonk', 'bork'])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getSubEntitiesByClasses([/bonk/, /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
+					expect(siren.getSubEntitiesByClasses(['bonk', /bork/])).to.be.an.instanceof(Array).with.lengthOf(2);
 					expect(siren.getSubEntitiesByClasses(['bonk', 'nope'])).to.be.an.instanceof(Array).and.to.be.empty;
 					expect(siren.getSubEntitiesByClasses([/bonk/, /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
+					expect(siren.getSubEntitiesByClasses(['bonk', /nope/])).to.be.an.instanceof(Array).and.to.be.empty;
 				});
 
 				it('getSubEntityByType', function() {


### PR DESCRIPTION
It can be annoying if you want to get a siren thing by more than 1 class. An example would be in my-courses when we want to maybe get all the hrefs for images that are both `banner` and `wide`. These functions aim to provide that functionality, where you can provide an array of classes and the things returned should be ones that match at least all of those provided.