### PR TITLE
Links don't require class, make sure to not blow up because of that

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -40,20 +40,21 @@ function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex, propertyToMatch
 		return [];
 	}
 
-	const vals = [];
+	const results = [];
 	for (var i = 0; i < arrayLike.length; i++) {
 		var like = arrayLike[i];
+		var val = like[propertyToMatch];
 
-		if (arrayOfStringOrRegex.every(
+		if (val && arrayOfStringOrRegex.every(
 			function(y) {
-				return contains(like[propertyToMatch], y);
+				return contains(val, y);
 			})
 		) {
-			vals.push(like);
+			results.push(like);
 		}
 	}
 
-	return vals;
+	return results;
 }
 
 module.exports = {

--- a/test/entity.js
+++ b/test/entity.js
@@ -595,6 +595,9 @@ describe('Entity', function() {
 						href: 'bar4',
 						class: ['bork', 'bonk'],
 						type: 'xxuq'
+					}, {
+						rel: ['foo5'],
+						href: 'bar5'
 					}];
 					siren = buildEntity();
 				});


### PR DESCRIPTION
If we try to call `entity.getLinksByClasses['y']` on an entity and any of those links don't have a `class` property defined (which is legit), we get `TypeError: Cannot read property 'indexOf' of undefined`. This PR introduces such a breaking link into the test values and then fixes the issue by ensuring there are values to call `.contains` on before doing so.