### PR TITLE
Homogenize two versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are three ways to use `node-siren-parser`'s functionality.
    npm install siren-parser
    ```
    and then `require` it as you would any other npm package.
-   
+
 2. An HTML import version of the parser is available via [`siren-parser-import`](https://github.com/Brightspace/siren-parser-import) (recommended approach for client-side usage).
 
 3. Alternatively, the parser is browserified and stored on the Brightspace CDN for client-side usage
@@ -24,11 +24,9 @@ There are three ways to use `node-siren-parser`'s functionality.
    var parsedEntity = window.D2L.Hypermedia.Siren.Parse('{"class":["foo","bar"]}');
    </script>
    ```
-   An alternate bundle of the siren parser is available that is exposed as a property of the global object.
-   ```html
-   <script src="https://s.brightspace.com/lib/siren-parser/{version}/siren-parser-global.js"></script>
-   ```
-   The client-side code will still use the `window.D2L.Hypermedia.Siren` object, but this addresses the risk of collisions with other modules on the page that are exposed by browserify's standalone UMD bundle.
+   Note that this is a `deumdify`'d browser bundle, which should prevent collisions with other modules on the page that are exposed by browserify's standalone UMD bundle.
+
+   (There is also a `siren-parser-global.js`, but as of v6.6.0 it is equivalent to `siren-parser.js`, as both are being `deumdify`'d. This version will be removed in the next major version bump.)
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebrowserify": "rimraf dist && mkdir dist",
     "browserify": "npm run browserify:umd && npm run browserify:global",
-    "browserify:umd": "browserify -g uglifyify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
+    "browserify:umd": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
     "browserify:global": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser-global.js",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "npm run lint && npm run test-no-style",


### PR DESCRIPTION
There have been som issues that arise from using the non-global version of the siren parser. Since there's no downside to using the -global version in contexts were it's not required (but there is a downside to using the non-global one where global one is required), we might as well just have one, deumdified, version.

For this (minor) release, we are simply making the two files the same. In the next major release, the -global.js file will be removed, as the new siren-parser.js is exactly equivalent to the old siren-parser-global.js.

(Note that this release will only go so far as `siren-parser-import` - I'll do the major release bump now as well, and propagate that through `siren-parser-import` and into other repos as well, since it's only really a breaking change in a small number of cases.)