### PR TITLE
Remove -global.js file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ There are three ways to use `node-siren-parser`'s functionality.
    ```
    Note that this is a `deumdify`'d browser bundle, which should prevent collisions with other modules on the page that are exposed by browserify's standalone UMD bundle.
 
-   (There is also a `siren-parser-global.js`, but as of v6.6.0 it is equivalent to `siren-parser.js`, as both are being `deumdify`'d. This version will be removed in the next major version bump.)
-
 ## API
 
 ```js

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "src/Entity.js",
   "scripts": {
     "prebrowserify": "rimraf dist && mkdir dist",
-    "browserify": "npm run browserify:umd && npm run browserify:global",
-    "browserify:umd": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
-    "browserify:global": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser-global.js",
+    "browserify": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
     "lint": "eslint --ignore-path .gitignore .",
     "test": "npm run lint && npm run test-no-style",
     "test-no-style": "export NODE_ENV=test; istanbul cover --source-map --dir ./coverage/unit --root src/ node_modules/.bin/_mocha -- --recursive ./test",


### PR DESCRIPTION
As of v6.6.0, the siren-parser.js and siren-parser-global.js files are equivalent (i.e. both deumdified). With a major version bump, we can remove the -global.js file.

As mentioned in the previous PR, this version will be propagated to `siren-parser-import`, then to everything else (unlike the previous PR, which was only propagated to `siren-parser-import`, so that anything using `siren-parser-import#^6.5.0` or similar would get it)