### PR TITLE
Converting to an ES6 module

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": ["@babel/preset-env"],
+  "env": {
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "brightspace/node-config",
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 node_modules
 coverage
 dist
-
+.nyc_output
 *.log
 *.swo
 *.swp
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
-sudo: false
 language: node_js
-node_js: stable
+node_js: node
 after_success:
   - npm run report-cov
-  - npm run browserify
-  - '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && [ "x$TRAVIS_TAG" != "x" ] && npm
-    run publish:cdn'
 deploy: # Travis will remove the dist/ folder before deploy if we don't include this
   skip_cleanup: true
   provider: npm
@@ -16,15 +12,3 @@ deploy: # Travis will remove the dist/ folder before deploy if we don't include 
   on:
     tags: true
     repo: Brightspace/node-siren-parser
-env:
-  global:
-    - secure: "HIAm5TRiT0dt2bsEQvTzrQ6y91hnCS1LP7T0iSefiw4Bhje+YEPbemSc28N1Cj07oyRc7n\
-        OjAV5bmGr3nyqCUvoy1nYdCVwSiIg77NeuNMcP6Mh3MNrYCp1n6i8ykn1cSJZOJLiNiMZEX\
-        4nLBzy9zWD+oftF7f9DEydIvLfQDvAJcYRSuEB3OSJmIVW75joRmiYax89dkEW/ikowsEUj\
-        MucZjW6tFrhzr8XfYI0fKykqhpD9L1ZU77NgjUn3L7wMqdwmeu/brMyq6FR6w3DW0bDoSKy\
-        ZfFnz4Tl9P6p3iOfM7wK0YxJxKKgjVA6EqvGaq7MFHc3LXbhZvWPYNnTmvRspxCvAYO3Twm\
-        OB4FUZLDX9kylINw/ajw0gng/K+I6z8cYOUbLIpERzENawSmgstcOafiHLtfjp8B5tBlT1q\
-        48K5mgrp05jaXuvmOgz0HdsSMfqOW+bOgn0zCqnHT2xER9Yd7VDSFqP9kcrJsNuYWr7qGJY\
-        9tb3nyLC8d7qUweMug4gcn6By6AyPHD6gCLo8FUqaGYTd+0IKp/aJNsmT8yq4p4K1anuN62\
-        qL+QhFMMX/b/dJ8LjHhqAHaAHO8ZZymG6bn9CWqqMOr0w/+jB2vVNgJaRQYAsI/OoFcZYtm\
-        QLYIhVk7waVg188HvbyVF1l3glkZsm7wrUACt8UAm8xFw="

--- a/README.md
+++ b/README.md
@@ -4,24 +4,34 @@
 
 Parses a Siren object (or Siren JSON string) into an Entity object that is intended to be easier to work with and test, and prevent having to parse replies from Siren APIs manually. Fully implements the [Siren spec](siren), including all restrictions and requirements on entities, links, fields, etc. Kinda complements [node-siren-writer](node-siren-writer), in that they're intended to sort of be opposites. Also includes a plugin for use with [chai](chai).
 
+## Installation
+
+Install from NPM:
+```shell
+npm install siren-parser
+```
+
 ## Usage
 
-There are three ways to use `node-siren-parser`'s functionality.
+There are three ways to use `siren-parser`'s functionality.
 
-1. You can install it from npm using
-   ```bash
-   npm install siren-parser
+1. In Node.js, `require` it as you would any other NPM package:
+   ```javascript
+   const SirenParse = require('siren-parser');
+   var parsedEntity = SirenParse('{"class":["foo","bar"]}');
    ```
-   and then `require` it as you would any other npm package.
 
-2. An HTML import version of the parser is available via [`siren-parser-import`](https://github.com/Brightspace/siren-parser-import) (recommended approach for client-side usage).
+2. An ES6 module is available as well for import:
+   ```javascript
+   import SirenParse from 'siren-parser';
+   var parsedEntity = SirenParse('{"class":["foo","bar"]}');
+   ```
 
-3. Alternatively, the parser is browserified and stored on the Brightspace CDN for client-side usage
+3. An ES6 module installed on the window as a global:
    ```html
-   <script src="https://s.brightspace.com/lib/siren-parser/{version}/siren-parser.js"></script>
-
+   <script type="module" src="siren-parser/global.js"></script>
    <script>
-   var parsedEntity = window.D2L.Hypermedia.Siren.Parse('{"class":["foo","bar"]}');
+   var parsedEntity = D2L.Hypermedia.Siren.Parse('{"class":["foo","bar"]}');
    </script>
    ```
    Note that this is a `deumdify`'d browser bundle, which should prevent collisions with other modules on the page that are exposed by browserify's standalone UMD bundle.

--- a/chai.js
+++ b/chai.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./src/chaiPlugin');

--- a/global.js
+++ b/global.js
@@ -1,0 +1,5 @@
+import SirenParse from './src/index';
+window.D2L = window.D2L || {};
+window.D2L.Hypermedia = window.D2L.Hypermedia || {};
+window.D2L.Hypermedia.Siren = window.D2L.Hypermedia.Siren || {};
+window.D2L.Hypermedia.Siren.Parse = SirenParse;

--- a/package.json
+++ b/package.json
@@ -1,29 +1,15 @@
 {
   "name": "siren-parser",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "Pretty much the opposite of dominicbarnes/node-siren-writer",
-  "main": "src/Entity.js",
+  "main": "dist/index.js",
+  "module": "src/index.js",
   "scripts": {
-    "prebrowserify": "rimraf dist && mkdir dist",
-    "browserify": "browserify -g uglifyify -p deumdify -s 'D2L.Hypermedia.Siren.Parse' src/Entity.js > ./dist/siren-parser.js",
-    "lint": "eslint --ignore-path .gitignore .",
-    "test": "npm run lint && npm run test-no-style",
-    "test-no-style": "cross-env NODE_ENV=test istanbul cover --source-map --dir ./coverage/unit --root src/ node_modules/mocha/bin/_mocha -- --recursive ./test",
-    "posttest": "istanbul report text-summary lcov",
-    "report-cov": "istanbul report lcovonly && coveralls < ./coverage/lcov.info",
-    "publish:cdn": "frau-publisher"
-  },
-  "config": {
-    "frauPublisher": {
-      "files": "./dist/*.js",
-      "moduleType": "lib",
-      "targetDirectory": "siren-parser",
-      "creds": {
-        "key": "AKIAIX7THWM4IO4CULRA",
-        "secretVar": "CDN_SECRET"
-      },
-      "versionVar": "TRAVIS_TAG"
-    }
+    "build": "babel src --out-dir ./dist --source-maps --plugins=add-module-exports",
+    "lint": "eslint src test --ext .js",
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "cross-env NODE_ENV=test nyc mocha",
+    "report-cov": "istanbul report lcovonly && coveralls < ./coverage/lcov.info"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
@@ -36,43 +22,33 @@
     "url": "https://github.com/Brightspace/node-siren-parser/issues"
   },
   "devDependencies": {
-    "babel-preset-latest": "^6.24.0",
-    "babelify": "^7.3.0",
-    "browserify": "^14.1.0",
-    "chai": "^3.3.0",
-    "coveralls": "^2.11.4",
-    "cross-env": "^5.0.5",
-    "deumdify": "^1.2.4",
-    "eslint": "^3.18.0",
-    "eslint-config-brightspace": "0.2.4",
-    "frau-publisher": "^2.6.2",
-    "istanbul": "0.4.5",
-    "mocha": "^3.2.0",
-    "nock": "^9.0.10",
-    "peanut-gallery": "^1.1.1",
-    "rimraf": "^2.6.1",
-    "sinon": "^2.1.0",
-    "sinon-chai": "^2.8.0",
-    "supertest": "^3.0.0",
-    "uglifyify": "^3.0.4"
+    "@babel/cli": "^7.1.2",
+    "@babel/core": "^7.1.2",
+    "@babel/node": "^7.0.0",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/register": "^7.0.0",
+    "babel-plugin-add-module-exports": "^1.0.0",
+    "babel-plugin-istanbul": "^5.1.0",
+    "chai": "^4.2.0",
+    "cross-env": "^5.2.0",
+    "eslint": "^5.8.0",
+    "eslint-config-brightspace": "^0.4.1",
+    "mocha": "^5.2.0",
+    "nock": "^10.0.2",
+    "nyc": "^13.1.0",
+    "sinon": "^7.1.1",
+    "sinon-chai": "^3.2.0",
+    "supertest": "^3.3.0"
   },
-  "eslintConfig": {
-    "extends": "brightspace",
-    "env": {
-      "es6": true,
-      "node": true
-    }
-  },
-  "browserify": {
-    "transform": [
-      [
-        "babelify",
-        {
-          "presets": [
-            "latest"
-          ]
-        }
-      ]
-    ]
+  "nyc": {
+    "require": [
+      "@babel/register"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "sourceMap": false,
+    "instrument": false
   }
 }

--- a/src/Action.js
+++ b/src/Action.js
@@ -1,11 +1,8 @@
-'use strict';
+import assert from './assert';
+import {contains, getMatchingValue, getMatchingValuesByAll, hasProperty} from './util.js';
+import Field from './Field';
 
-const
-	assert = require('./assert'),
-	Field = require('./Field'),
-	util = require('./util');
-
-function Action(action) {
+export default function Action(action) {
 	if (action instanceof Action) {
 		return action;
 	}
@@ -82,7 +79,7 @@ Action.prototype.toJSON = function() {
 };
 
 Action.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && util.contains(this.class, cls);
+	return this.class instanceof Array && contains(this.class, cls);
 };
 
 Action.prototype.hasField = function(fieldName) {
@@ -90,15 +87,15 @@ Action.prototype.hasField = function(fieldName) {
 };
 
 Action.prototype.hasFieldByName = function(fieldName) {
-	return util.hasProperty(this._fieldsByName, fieldName);
+	return hasProperty(this._fieldsByName, fieldName);
 };
 
 Action.prototype.hasFieldByClass = function(fieldClass) {
-	return util.hasProperty(this._fieldsByClass, fieldClass);
+	return hasProperty(this._fieldsByClass, fieldClass);
 };
 
 Action.prototype.hasFieldByType = function(fieldType) {
-	return util.hasProperty(this._fieldsByType, fieldType);
+	return hasProperty(this._fieldsByType, fieldType);
 };
 
 Action.prototype.getField = function(fieldName) {
@@ -106,37 +103,35 @@ Action.prototype.getField = function(fieldName) {
 };
 
 Action.prototype.getFieldByName = function(fieldName) {
-	return util.getMatchingValue(this._fieldsByName, fieldName);
+	return getMatchingValue(this._fieldsByName, fieldName);
 };
 
 Action.prototype.getFieldByClass = function(fieldClass) {
-	const vals = util.getMatchingValue(this._fieldsByClass, fieldClass);
+	const vals = getMatchingValue(this._fieldsByClass, fieldClass);
 	return vals ? vals[0] : undefined;
 };
 
 Action.prototype.getFieldsByClass = function(fieldClass) {
-	const vals = util.getMatchingValue(this._fieldsByClass, fieldClass);
+	const vals = getMatchingValue(this._fieldsByClass, fieldClass);
 	return vals ? vals.slice() : [];
 };
 
 Action.prototype.getFieldByClasses = function(fieldClasses) {
-	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses, 'class');
+	const vals = getMatchingValuesByAll(this.fields, fieldClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Action.prototype.getFieldsByClasses = function(fieldClasses) {
-	const vals = util.getMatchingValuesByAll(this.fields, fieldClasses, 'class');
+	const vals = getMatchingValuesByAll(this.fields, fieldClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
 Action.prototype.getFieldByType = function(fieldType) {
-	const vals = util.getMatchingValue(this._fieldsByType, fieldType);
+	const vals = getMatchingValue(this._fieldsByType, fieldType);
 	return vals ? vals[0] : undefined;
 };
 
 Action.prototype.getFieldsByType = function(fieldType) {
-	const vals = util.getMatchingValue(this._fieldsByType, fieldType);
+	const vals = getMatchingValue(this._fieldsByType, fieldType);
 	return vals ? vals.slice() : [];
 };
-
-module.exports = Action;

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,8 +1,5 @@
-'use strict';
-
-const
-	assert = require('./assert'),
-	util = require('./util');
+import assert from './assert';
+import {contains} from './util';
 
 const VALID_TYPES = [
 	'hidden',
@@ -26,7 +23,7 @@ const VALID_TYPES = [
 	'file'
 ];
 
-function Field(field) {
+export default function Field(field) {
 	if (field instanceof Field) {
 		return field;
 	}
@@ -38,8 +35,7 @@ function Field(field) {
 	assert('string' === typeof field.name, 'field.name must be a string, got ' + JSON.stringify(field.name));
 	assert('undefined' === typeof field.class || Array.isArray(field.class),
 		'field.class must be an array or undefined, got ' + JSON.stringify(field.class));
-	assert('undefined' === typeof field.type
-		|| ('string' === typeof field.type && VALID_TYPES.indexOf(field.type.toLowerCase()) > -1),
+	assert('undefined' === typeof field.type || ('string' === typeof field.type && VALID_TYPES.indexOf(field.type.toLowerCase()) > -1),
 		'field.type must be a valid field type string or undefined, got ' + JSON.stringify(field.type));
 	assert('undefined' === typeof field.title || 'string' === typeof field.title,
 		'field.title must be a string or undefined, got ' + JSON.stringify(field.title));
@@ -74,7 +70,5 @@ Field.prototype.toJSON = function() {
 };
 
 Field.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && util.contains(this.class, cls);
+	return this.class instanceof Array && contains(this.class, cls);
 };
-
-module.exports = Field;

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,10 +1,7 @@
-'use strict';
+import assert from './assert';
+import {contains} from './util';
 
-const
-	assert = require('./assert'),
-	util = require('./util');
-
-function Link(link) {
+export default function Link(link) {
 	if (link instanceof Link) {
 		return link;
 	}
@@ -49,7 +46,5 @@ Link.prototype.toJSON = function() {
 };
 
 Link.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && util.contains(this.class, cls);
+	return this.class instanceof Array && contains(this.class, cls);
 };
-
-module.exports = Link;

--- a/src/assert.js
+++ b/src/assert.js
@@ -1,7 +1,5 @@
-'use strict';
-
-module.exports = function(expectation, msg) {
+export default function(expectation, msg) {
 	if (!expectation) {
 		throw new Error(msg);
 	}
-};
+}

--- a/src/chaiPlugin.js
+++ b/src/chaiPlugin.js
@@ -1,12 +1,9 @@
-'use strict';
+import Action from './Action';
+import Entity from './index';
+import Field from './Field';
+import Link from './Link';
 
-const
-	Action = require('./Action'),
-	Entity = require('./Entity'),
-	Field = require('./Field'),
-	Link = require('./Link');
-
-module.exports = function(chai, utils) {
+export default function(chai, utils) {
 	const Assertion = chai.Assertion;
 
 	// .all.
@@ -135,4 +132,4 @@ module.exports = function(chai, utils) {
 	}
 	objectProperty('sirenProperty', 'properties', Entity);
 	objectProperty('sirenProperties', 'properties', Entity);
-};
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,9 @@
-'use strict';
+import Action from './Action';
+import assert from './assert';
+import Link from './Link';
+import {contains, getMatchingValue, getMatchingValuesByAll, hasProperty} from './util.js';
 
-const
-	assert = require('./assert'),
-	util = require('./util');
-
-const
-	Action = require('./Action'),
-	Link = require('./Link');
-
-function Entity(entity) {
+export default function Entity(entity) {
 	entity = entity || {};
 
 	if (entity instanceof Entity) {
@@ -174,23 +169,23 @@ Entity.prototype.hasAction = function(actionName) {
 };
 
 Entity.prototype.hasActionByName = function(actionName) {
-	return util.hasProperty(this._actionsByName, actionName);
+	return hasProperty(this._actionsByName, actionName);
 };
 
 Entity.prototype.hasActionByClass = function(actionClass) {
-	return util.hasProperty(this._actionsByClass, actionClass);
+	return hasProperty(this._actionsByClass, actionClass);
 };
 
 Entity.prototype.hasActionByMethod = function(actionMethod) {
-	return util.hasProperty(this._actionsByMethod, actionMethod);
+	return hasProperty(this._actionsByMethod, actionMethod);
 };
 
 Entity.prototype.hasActionByType = function(actionType) {
-	return util.hasProperty(this._actionsByType, actionType);
+	return hasProperty(this._actionsByType, actionType);
 };
 
 Entity.prototype.hasClass = function(cls) {
-	return this.class instanceof Array && util.contains(this.class, cls);
+	return this.class instanceof Array && contains(this.class, cls);
 };
 
 Entity.prototype.hasEntity = function(entityRel) {
@@ -202,7 +197,7 @@ Entity.prototype.hasEntityByRel = function(entityRel) {
 };
 
 Entity.prototype.hasSubEntityByRel = function(entityRel) {
-	return util.hasProperty(this._entitiesByRel, entityRel);
+	return hasProperty(this._entitiesByRel, entityRel);
 };
 
 Entity.prototype.hasEntityByClass = function(entityClass) {
@@ -210,7 +205,7 @@ Entity.prototype.hasEntityByClass = function(entityClass) {
 };
 
 Entity.prototype.hasSubEntityByClass = function(entityClass) {
-	return util.hasProperty(this._entitiesByClass, entityClass);
+	return hasProperty(this._entitiesByClass, entityClass);
 };
 
 Entity.prototype.hasEntityByType = function(entityType) {
@@ -218,7 +213,7 @@ Entity.prototype.hasEntityByType = function(entityType) {
 };
 
 Entity.prototype.hasSubEntityByType = function(entityType) {
-	return util.hasProperty(this._entitiesByType, entityType);
+	return hasProperty(this._entitiesByType, entityType);
 };
 
 Entity.prototype.hasLink = function(linkRel) {
@@ -226,19 +221,19 @@ Entity.prototype.hasLink = function(linkRel) {
 };
 
 Entity.prototype.hasLinkByRel = function(linkRel) {
-	return util.hasProperty(this._linksByRel, linkRel);
+	return hasProperty(this._linksByRel, linkRel);
 };
 
 Entity.prototype.hasLinkByClass = function(linkClass) {
-	return util.hasProperty(this._linksByClass, linkClass);
+	return hasProperty(this._linksByClass, linkClass);
 };
 
 Entity.prototype.hasLinkByType = function(linkType) {
-	return util.hasProperty(this._linksByType, linkType);
+	return hasProperty(this._linksByType, linkType);
 };
 
 Entity.prototype.hasProperty = function(property) {
-	return util.hasProperty(this, 'properties') && util.hasProperty(this.properties, property);
+	return hasProperty(this, 'properties') && hasProperty(this.properties, property);
 };
 
 Entity.prototype.getAction = function(actionName) {
@@ -246,46 +241,46 @@ Entity.prototype.getAction = function(actionName) {
 };
 
 Entity.prototype.getActionByName = function(actionName) {
-	return util.getMatchingValue(this._actionsByName, actionName);
+	return getMatchingValue(this._actionsByName, actionName);
 };
 
 Entity.prototype.getActionByClass = function(actionClass) {
-	const vals = util.getMatchingValue(this._actionsByClass, actionClass);
+	const vals = getMatchingValue(this._actionsByClass, actionClass);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByClass = function(actionClass) {
-	const vals = util.getMatchingValue(this._actionsByClass, actionClass);
+	const vals = getMatchingValue(this._actionsByClass, actionClass);
 	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getActionByClasses = function(actionClasses) {
-	const vals = util.getMatchingValuesByAll(this.actions, actionClasses, 'class');
+	const vals = getMatchingValuesByAll(this.actions, actionClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByClasses = function(actionClasses) {
-	const vals = util.getMatchingValuesByAll(this.actions, actionClasses, 'class');
+	const vals = getMatchingValuesByAll(this.actions, actionClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
 Entity.prototype.getActionByMethod = function(actionMethod) {
-	const vals = util.getMatchingValue(this._actionsByMethod, actionMethod);
+	const vals = getMatchingValue(this._actionsByMethod, actionMethod);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByMethod = function(actionMethod) {
-	const vals = util.getMatchingValue(this._actionsByMethod, actionMethod);
+	const vals = getMatchingValue(this._actionsByMethod, actionMethod);
 	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getActionByType = function(actionType) {
-	const vals = util.getMatchingValue(this._actionsByType, actionType);
+	const vals = getMatchingValue(this._actionsByType, actionType);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getActionsByType = function(actionType) {
-	const vals = util.getMatchingValue(this._actionsByType, actionType);
+	const vals = getMatchingValue(this._actionsByType, actionType);
 	return vals ? vals.slice() : [];
 };
 
@@ -298,52 +293,52 @@ Entity.prototype.getLinks = function(linkRel) {
 };
 
 Entity.prototype.getLinkByRel = function(linkRel) {
-	const vals = util.getMatchingValue(this._linksByRel, linkRel);
+	const vals = getMatchingValue(this._linksByRel, linkRel);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByRel = function(linkRel) {
-	const vals = util.getMatchingValue(this._linksByRel, linkRel);
+	const vals = getMatchingValue(this._linksByRel, linkRel);
 	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getLinkByRels = function(linkRels) {
-	const vals = util.getMatchingValuesByAll(this.links, linkRels, 'rel');
+	const vals = getMatchingValuesByAll(this.links, linkRels, 'rel');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByRels = function(linkRels) {
-	const vals = util.getMatchingValuesByAll(this.links, linkRels, 'rel');
+	const vals = getMatchingValuesByAll(this.links, linkRels, 'rel');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
 Entity.prototype.getLinkByClass = function(linkClass) {
-	const vals = util.getMatchingValue(this._linksByClass, linkClass);
+	const vals = getMatchingValue(this._linksByClass, linkClass);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByClass = function(linkClass) {
-	const vals = util.getMatchingValue(this._linksByClass, linkClass);
+	const vals = getMatchingValue(this._linksByClass, linkClass);
 	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getLinkByClasses = function(linkClasses) {
-	const vals = util.getMatchingValuesByAll(this.links, linkClasses, 'class');
+	const vals = getMatchingValuesByAll(this.links, linkClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByClasses = function(linkClasses) {
-	const vals = util.getMatchingValuesByAll(this.links, linkClasses, 'class');
+	const vals = getMatchingValuesByAll(this.links, linkClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
 Entity.prototype.getLinkByType = function(linkType) {
-	const vals = util.getMatchingValue(this._linksByType, linkType);
+	const vals = getMatchingValue(this._linksByType, linkType);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getLinksByType = function(linkType) {
-	const vals = util.getMatchingValue(this._linksByType, linkType);
+	const vals = getMatchingValue(this._linksByType, linkType);
 	return vals ? vals.slice() : [];
 };
 
@@ -356,53 +351,51 @@ Entity.prototype.getSubEntities = function(entityRel) {
 };
 
 Entity.prototype.getSubEntityByRel = function(entityRel) {
-	const vals = util.getMatchingValue(this._entitiesByRel, entityRel);
+	const vals = getMatchingValue(this._entitiesByRel, entityRel);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getSubEntitiesByRel = function(entityRel) {
-	const vals = util.getMatchingValue(this._entitiesByRel, entityRel);
+	const vals = getMatchingValue(this._entitiesByRel, entityRel);
 	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getSubEntityByRels = function(entityRels) {
-	const vals = util.getMatchingValuesByAll(this.entities, entityRels, 'rel');
+	const vals = getMatchingValuesByAll(this.entities, entityRels, 'rel');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getSubEntitiesByRels = function(entityRels) {
-	const vals = util.getMatchingValuesByAll(this.entities, entityRels, 'rel');
+	const vals = getMatchingValuesByAll(this.entities, entityRels, 'rel');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
 Entity.prototype.getSubEntityByClass = function(entityClass) {
-	const vals = util.getMatchingValue(this._entitiesByClass, entityClass);
+	const vals = getMatchingValue(this._entitiesByClass, entityClass);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getSubEntitiesByClass = function(entityClass) {
-	const vals = util.getMatchingValue(this._entitiesByClass, entityClass);
+	const vals = getMatchingValue(this._entitiesByClass, entityClass);
 	return vals ? vals.slice() : [];
 };
 
 Entity.prototype.getSubEntityByClasses = function(entityClasses) {
-	const vals = util.getMatchingValuesByAll(this.entities, entityClasses, 'class');
+	const vals = getMatchingValuesByAll(this.entities, entityClasses, 'class');
 	return vals && vals.length > 0 ? vals[0] : undefined;
 };
 
 Entity.prototype.getSubEntitiesByClasses = function(entityClasses) {
-	const vals = util.getMatchingValuesByAll(this.entities, entityClasses, 'class');
+	const vals = getMatchingValuesByAll(this.entities, entityClasses, 'class');
 	return vals && vals.length > 0 ? vals.slice() : [];
 };
 
 Entity.prototype.getSubEntityByType = function(entityType) {
-	const vals = util.getMatchingValue(this._entitiesByType, entityType);
+	const vals = getMatchingValue(this._entitiesByType, entityType);
 	return vals ? vals[0] : undefined;
 };
 
 Entity.prototype.getSubEntitiesByType = function(entityType) {
-	const vals = util.getMatchingValue(this._entitiesByType, entityType);
+	const vals = getMatchingValue(this._entitiesByType, entityType);
 	return vals ? vals.slice() : [];
 };
-
-module.exports = Entity;

--- a/src/superagent.js
+++ b/src/superagent.js
@@ -1,11 +1,8 @@
-'use strict';
+import assert from './assert';
+import Action from './Action';
+import Entity from './index';
 
-const
-	assert = require('assert'),
-	Action = require('./Action'),
-	Entity = require('./Entity');
-
-function parseSiren(res, fn) {
+export function parse(res, fn) {
 	if ('string' === typeof res) {
 		return new Entity(res);
 	}
@@ -54,7 +51,7 @@ function submitHelper(req) {
 	};
 }
 
-function performAction(request, action) {
+export function perform(request, action) {
 	assert(request);
 	assert(action instanceof Action);
 	return request[action.method.toLowerCase()](action.href)
@@ -62,8 +59,3 @@ function performAction(request, action) {
 		.type(action.type)
 		.submit(action.fields || []);
 }
-
-module.exports = {
-	parse: parseSiren,
-	perform: performAction
-};

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,4 @@
-'use strict';
-
-function contains(arrayLike, stringOrRegex) {
+export function contains(arrayLike, stringOrRegex) {
 	if ('string' === typeof stringOrRegex) {
 		return arrayLike.indexOf(stringOrRegex) > -1;
 	}
@@ -12,7 +10,7 @@ function contains(arrayLike, stringOrRegex) {
 	return (match !== undefined);
 }
 
-function hasProperty(objectLike, stringOrRegex) {
+export function hasProperty(objectLike, stringOrRegex) {
 	if ('string' === typeof stringOrRegex) {
 		return objectLike.hasOwnProperty(stringOrRegex);
 	}
@@ -20,7 +18,7 @@ function hasProperty(objectLike, stringOrRegex) {
 	return contains(Object.keys(objectLike), stringOrRegex);
 }
 
-function getMatchingValue(objectLike, stringOrRegex) {
+export function getMatchingValue(objectLike, stringOrRegex) {
 	if ('string' === typeof stringOrRegex) {
 		return objectLike[stringOrRegex];
 	}
@@ -35,7 +33,7 @@ function getMatchingValue(objectLike, stringOrRegex) {
 	}
 }
 
-function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex, propertyToMatch) {
+export function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex, propertyToMatch) {
 	if (!Array.isArray(arrayOfStringOrRegex) || !propertyToMatch) {
 		return [];
 	}
@@ -56,10 +54,3 @@ function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex, propertyToMatch
 
 	return results;
 }
-
-module.exports = {
-	contains: contains,
-	hasProperty: hasProperty,
-	getMatchingValue: getMatchingValue,
-	getMatchingValuesByAll: getMatchingValuesByAll
-};

--- a/superagent.js
+++ b/superagent.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./src/superagent');

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "chai": true
+  }
+}

--- a/test/action.js
+++ b/test/action.js
@@ -1,15 +1,9 @@
-/* global describe, it, beforeEach, afterEach */
+import Action from '../src/Action';
+import {expect, use} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
-'use strict';
-
-const
-	chai = require('chai'),
-	expect = chai.expect,
-	sinon = require('sinon');
-
-const Action = require('../src/Action');
-
-chai.use(require('sinon-chai'));
+use(sinonChai);
 
 describe('Action', function() {
 	let
@@ -20,7 +14,7 @@ describe('Action', function() {
 	beforeEach(function() {
 		resource = {};
 		siren = undefined;
-		sandbox = sinon.sandbox.create();
+		sandbox = sinon.createSandbox();
 		sandbox.stub(console, 'error');
 		sandbox.stub(console, 'warn');
 	});

--- a/test/chaiPlugin.js
+++ b/test/chaiPlugin.js
@@ -1,19 +1,11 @@
-/* global describe, it, beforeEach */
+import Action from '../src/Action';
+import Entity from '../src/index';
+import {expect, use} from 'chai';
+import Field from '../src/Field';
+import Link from '../src/Link';
+import sirenChai from '../src/chaiPlugin.js';
 
-'use strict';
-
-const
-	chai = require('chai'),
-	expect = chai.expect;
-
-const
-	Action = require('../src/Action'),
-	Entity = require('../'),
-	Field = require('../src/Field'),
-	Link = require('../src/Link'),
-	sirenChai = require('../chai');
-
-chai.use(sirenChai);
+use(sirenChai);
 
 describe('Chai Plugin v2', function() {
 	let

--- a/test/entity.js
+++ b/test/entity.js
@@ -1,18 +1,11 @@
-/* global describe, it, beforeEach, afterEach */
+import Action from '../src/Action';
+import Entity from '../src/index';
+import {expect, use} from 'chai';
+import Link from '../src/Link';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
-'use strict';
-
-const
-	chai = require('chai'),
-	expect = chai.expect,
-	sinon = require('sinon');
-
-const
-	Action = require('../src/Action'),
-	Entity = require('../'),
-	Link = require('../src/Link');
-
-chai.use(require('sinon-chai'));
+use(sinonChai);
 
 describe('Entity', function() {
 	let
@@ -23,7 +16,7 @@ describe('Entity', function() {
 	beforeEach(function() {
 		resource = {};
 		siren = undefined;
-		sandbox = sinon.sandbox.create();
+		sandbox = sinon.createSandbox();
 		sandbox.stub(console, 'error');
 		sandbox.stub(console, 'warn');
 	});

--- a/test/field.js
+++ b/test/field.js
@@ -1,15 +1,9 @@
-/* global describe, it, beforeEach, afterEach */
+import {expect, use} from 'chai';
+import Field from '../src/Field';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
-'use strict';
-
-const
-	chai = require('chai'),
-	expect = chai.expect,
-	sinon = require('sinon');
-
-const Field = require('../src/Field');
-
-chai.use(require('sinon-chai'));
+use(sinonChai);
 
 describe('Field', function() {
 	let
@@ -20,7 +14,7 @@ describe('Field', function() {
 	beforeEach(function() {
 		resource = {};
 		siren = undefined;
-		sandbox = sinon.sandbox.create();
+		sandbox = sinon.createSandbox();
 		sandbox.stub(console, 'error');
 		sandbox.stub(console, 'warn');
 	});

--- a/test/link.js
+++ b/test/link.js
@@ -1,15 +1,9 @@
-/* global describe, it, beforeEach, afterEach */
+import {expect, use} from 'chai';
+import Link from '../src/Link';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
-'use strict';
-
-const
-	chai = require('chai'),
-	expect = chai.expect,
-	sinon = require('sinon');
-
-const Link = require('../src/Link');
-
-chai.use(require('sinon-chai'));
+use(sinonChai);
 
 describe('Link', function() {
 	let
@@ -20,7 +14,7 @@ describe('Link', function() {
 	beforeEach(function() {
 		resource = {};
 		siren = undefined;
-		sandbox = sinon.sandbox.create();
+		sandbox = sinon.createSandbox();
 		sandbox.stub(console, 'error');
 		sandbox.stub(console, 'warn');
 	});

--- a/test/superagent.js
+++ b/test/superagent.js
@@ -1,22 +1,16 @@
-/* global describe, it, beforeEach, afterEach */
-
-'use strict';
+import Action from '../src/Action';
+import Entity from '../src/index';
+import {expect, use} from 'chai';
+import sirenChai from '../src/chaiPlugin';
+import {parse, perform} from '../src/superagent';
+import sinonChai from 'sinon-chai';
 
 const
-	chai = require('chai'),
-	expect = chai.expect,
 	nock = require('nock'),
-	sinonChai = require('sinon-chai'),
 	request = require('supertest');
 
-const
-	Action = require('../src/Action'),
-	Entity = require('../'),
-	sirenChai = require('../chai'),
-	sirenSuperagent = require('../superagent');
-
-chai.use(sinonChai);
-chai.use(sirenChai);
+use(sinonChai);
+use(sirenChai);
 
 describe('Siren Superagent Plugin', function() {
 	let app, src;
@@ -40,7 +34,7 @@ describe('Siren Superagent Plugin', function() {
 
 			request(src)
 				.get('/')
-				.parse(sirenSuperagent.parse)
+				.parse(parse)
 				.expect(200)
 				.expect(function(res) {
 					expect(res.body).to.be.an.instanceof(Entity);
@@ -56,7 +50,7 @@ describe('Siren Superagent Plugin', function() {
 
 			request(src)
 				.get('/')
-				.parse(sirenSuperagent.parse)
+				.parse(parse)
 				.end(function(err, res) {
 					expect(err).to.be.an.instanceof(SyntaxError);
 					expect(res).to.be.undefined;
@@ -65,7 +59,7 @@ describe('Siren Superagent Plugin', function() {
 		});
 
 		it('should parse a string as a siren entity', function() {
-			const entity = sirenSuperagent.parse('{}');
+			const entity = parse('{}');
 			expect(entity).to.be.an.instanceof(Entity);
 		});
 	});
@@ -89,7 +83,7 @@ describe('Siren Superagent Plugin', function() {
 				.reply(200);
 
 			const action = buildAction();
-			sirenSuperagent.perform(request(src), action)
+			perform(request(src), action)
 				.expect(200)
 				.end(done);
 		});
@@ -108,7 +102,7 @@ describe('Siren Superagent Plugin', function() {
 					}
 				];
 				const action = buildAction();
-				sirenSuperagent.perform(request(src), action)
+				perform(request(src), action)
 					.expect(200)
 					.end(done);
 			});
@@ -127,7 +121,7 @@ describe('Siren Superagent Plugin', function() {
 					}
 				];
 				const action = buildAction();
-				sirenSuperagent.perform(request(src), action)
+				perform(request(src), action)
 					.expect(200)
 					.end(done);
 			});
@@ -147,7 +141,7 @@ describe('Siren Superagent Plugin', function() {
 				.reply(200);
 
 			const action = buildAction();
-			sirenSuperagent.perform(request(src), action)
+			perform(request(src), action)
 				.submit([
 					{
 						name: 'query',
@@ -165,7 +159,7 @@ describe('Siren Superagent Plugin', function() {
 				.reply(200);
 
 			const action = buildAction();
-			sirenSuperagent.perform(request(src), action)
+			perform(request(src), action)
 				.submit({query: 'parameter'})
 				.expect(200)
 				.end(done);
@@ -178,7 +172,7 @@ describe('Siren Superagent Plugin', function() {
 				.reply(200);
 
 			const action = buildAction();
-			sirenSuperagent.perform(request(src), action)
+			perform(request(src), action)
 				.submit('query=parameter')
 				.expect(200)
 				.end(done);


### PR DESCRIPTION
This also made sense to become an ES6 module. Instead of browserify-ing and publishing to the CDN, it will now transpile to ES5 into `dist`, which is what Node.js can continue to use. I also created a `global.js` that continues to install the parser on `D2L.Hypermedia.Siren.Parse` and can be included via `<script type="module">`.