### PR TITLE
Pass through unspecified field metadata

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -40,33 +40,11 @@ export default function Field(field) {
 	assert('undefined' === typeof field.title || 'string' === typeof field.title,
 		'field.title must be a string or undefined, got ' + JSON.stringify(field.title));
 
-	this.name = field.name;
-
-	if (field.class) {
-		this.class = field.class;
-	}
-
-	if (field.type) {
-		this.type = field.type;
-	}
-
-	if (field.hasOwnProperty('value')) {
-		this.value = field.value;
-	}
-
-	if (field.title) {
-		this.title = field.title;
-	}
+	Object.assign(this, field);
 }
 
 Field.prototype.toJSON = function() {
-	return {
-		name: this.name,
-		class: this.class,
-		type: this.type,
-		value: this.value,
-		title: this.title
-	};
+	return Object.assign({}, this);
 };
 
 Field.prototype.hasClass = function(cls) {

--- a/test/field.js
+++ b/test/field.js
@@ -124,6 +124,14 @@ describe('Field', function() {
 		});
 	});
 
+	describe('pass-through', function() {
+		it('should pass unspecified fields through', function() {
+			resource.options = [{ value: 'Foo' }, { value: 'Bar' }];
+			siren = buildField();
+			expect(siren.options[1].value).to.equal('Bar');
+		});
+	});
+
 	describe('toJSON', function() {
 		function toJSON() {
 			return JSON.stringify(buildField());


### PR DESCRIPTION
Allow non-spec field metadata by preserving it in the resulting Field object.