### PR TITLE
Update nyc

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "babel src --out-dir ./dist --source-maps --plugins=add-module-exports",
     "lint": "eslint src test --ext .js",
     "test": "npm run lint && npm run test:unit",
-    "test:unit": "cross-env NODE_ENV=test nyc mocha",
+    "test:unit": "nyc mocha",
     "report-cov": "istanbul report lcovonly && coveralls < ./coverage/lcov.info"
   },
   "files": [
@@ -35,12 +35,11 @@
     "babel-plugin-add-module-exports": "^1.0.0",
     "babel-plugin-istanbul": "^5.1.0",
     "chai": "^4.2.0",
-    "cross-env": "^5.2.0",
     "eslint": "^5.8.0",
     "eslint-config-brightspace": "^0.4.1",
     "mocha": "^5.2.0",
     "nock": "^10.0.2",
-    "nyc": "^13.1.0",
+    "nyc": "^15.1.0",
     "sinon": "^7.1.1",
     "sinon-chai": "^3.2.0",
     "supertest": "^3.3.0"


### PR DESCRIPTION
There are a bunch of outdated packages here, but looks like there's an issue with this version of `nyc` specifically, https://github.com/istanbuljs/nyc/issues/1205. Updating just that for now, but should really get things updated in general here, as well as move to GH Actions.

(Also removed `cross-env` since it's doing nothing of value here.)