### PR TITLE
US127946: Update Siren Field Min/Max 

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -62,11 +62,11 @@ export default function Field(field) {
 		this.title = field.title;
 	}
 
-	if (field.min !== undefined) {
+	if (typeof field.min === 'number') {
 		this.min = field.min;
 	}
 
-	if (field.max !== undefined) {
+	if (typeof field.max === 'number') {
 		this.max = field.max;
 	}
 }

--- a/src/Field.js
+++ b/src/Field.js
@@ -62,11 +62,11 @@ export default function Field(field) {
 		this.title = field.title;
 	}
 
-	if (field.min) {
+	if (field.min !== undefined) {
 		this.min = field.min;
 	}
 
-	if (field.max) {
+	if (field.max !== undefined) {
 		this.max = field.max;
 	}
 }

--- a/test/field.js
+++ b/test/field.js
@@ -125,10 +125,22 @@ describe('Field', function() {
 	});
 
 	describe('min', function() {
-		it('should parse min', function() {
+		it('should parse min of 0', function() {
 			resource.min = 0;
 			siren = buildField();
 			expect(siren.min).to.equal(0);
+		});
+
+		it('should parse min of 1', function() {
+			resource.min = 1;
+			siren = buildField();
+			expect(siren.min).to.equal(1);
+		});
+
+		it ('should not have min if undefined', function() {
+			resource.min = undefined;
+			siren = buildField();
+			expect(siren.min).to.be.undefined;
 		});
 
 		it('should require min be a number, if supplied', function() {
@@ -138,10 +150,22 @@ describe('Field', function() {
 	});
 
 	describe('max', function() {
-		it('should parse max', function() {
+		it('should parse max of 0', function() {
+			resource.max = 0;
+			siren = buildField();
+			expect(siren.max).to.equal(0);
+		});
+
+		it('should parse max of 9999', function() {
 			resource.max = 9999;
 			siren = buildField();
 			expect(siren.max).to.equal(9999);
+		});
+
+		it ('should not have max if undefined', function() {
+			resource.max = undefined;
+			siren = buildField();
+			expect(siren.max).to.be.undefined;
 		});
 
 		it('should require max be a number, if supplied', function() {

--- a/test/field.js
+++ b/test/field.js
@@ -126,9 +126,9 @@ describe('Field', function() {
 
 	describe('min', function() {
 		it('should parse min', function() {
-			resource.min = 1;
+			resource.min = 0;
 			siren = buildField();
-			expect(siren.min).to.equal(1);
+			expect(siren.min).to.equal(0);
 		});
 
 		it('should require min be a number, if supplied', function() {


### PR DESCRIPTION
- Changing from original comparison relying on falsy to an explicit comparison, to allow 0 as a valid min 
- This change is required for US127946 - we are matching the FACE Quiz validation with the classic quizzing validation, which now allows grace limit to be set to 0.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F603513003912&fdp=true?fdp=true