### PR TITLE
fix: check if `arrayLike` is actually an array

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -46,7 +46,7 @@ export function getMatchingValue(objectLike, stringOrRegex) {
 }
 
 export function getMatchingValuesByAll(arrayLike, arrayOfStringOrRegex, propertyToMatch) {
-	if (!Array.isArray(arrayOfStringOrRegex) || !propertyToMatch) {
+	if (!Array.isArray(arrayLike) || !Array.isArray(arrayOfStringOrRegex) || !propertyToMatch) {
 		return [];
 	}
 


### PR DESCRIPTION
Been seeing these errors when working on tests for `d2l-rubric`.
```
"Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'length')", source: http://localhost:8000/node_modules/siren-parser/src/util.js (54)
```