### PR TITLE
Add additional exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -399,3 +399,9 @@ Entity.prototype.getSubEntitiesByType = function(entityType) {
 	const vals = getMatchingValue(this._entitiesByType, entityType);
 	return vals ? vals.slice() : [];
 };
+
+export {
+	Entity,
+	Action,
+	Link
+};


### PR DESCRIPTION
Currently using this package in the UCE project, and adding some extensions to it to help with token management.

https://github.com/Brightspace/unified-content-experience/blob/352c8b86053cc2f95fe4574f3c4303b8a8a0c9a3/src/util/controller-framework/entity-parsing/entity-parser.js

Unfortunately, I need to do importing by indexing into the file structure for the package to extend Action and Link, and I don't want to be doing that.  This PR adds exports to the index file for Entity, Action, and Link so that I can import them all from the package itself.

`import { Action, Entity, Link } from 'siren-parser'`

** Note: tested this in the UCE project to make sure the default export still works, so this will be no change to anyone currently using the project