### PR TITLE
Update readme with new/correct import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are three ways to use `siren-parser`'s functionality.
 
 2. An ES6 module is available as well for import:
    ```javascript
-   import SirenParse from 'siren-parser';
+   import { default as SirenParse } from 'siren-parser';
    var parsedEntity = SirenParse('{"class":["foo","bar"]}');
    ```
    You can also import `Action`, `Entity`, and `Link` by name if you need to add custom functionality to parsed entities.


### PR DESCRIPTION
tl;dr [this StackOverflow post](https://stackoverflow.com/a/33705077/271473).

Turns out Babel 5 had a hack in place for default exports such that when there was _only_ a default export, it was set as just `module.exports`. However, with the new exports introduced in #39, that hack no longer applies, so our export is now:

```js
{
  default: Entity,
  Link,
  Action,
  Field
}
```

This means that existing usages need to be updated slightly - arguably this could be seen as a breaking change, but in reality this is more akin to fixing a weird behaviour that has been sitting in wait since we updated to Babel >5.