### PR TITLE
Revert `exports` change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ There are three ways to use `siren-parser`'s functionality.
    import SirenParse from 'siren-parser';
    var parsedEntity = SirenParse('{"class":["foo","bar"]}');
    ```
-   You can also import `Action`, `Entity`, and `Link` by name if you need to add custom functionality to parsed entities.
-   ```javascript
-   import SirenParse, { Action, Entity, Link } from 'siren-parser';
-   Entity.prototype.printEntity = function() { console.log(this) };
-   var parsedEntity = SirenParse('{"class":["foo","bar"]}'); // parsedEntity will have printEntity()
-   ```
 
 3. An ES6 module installed on the window as a global:
    ```html

--- a/src/index.js
+++ b/src/index.js
@@ -399,9 +399,3 @@ Entity.prototype.getSubEntitiesByType = function(entityType) {
 	const vals = getMatchingValue(this._entitiesByType, entityType);
 	return vals ? vals.slice() : [];
 };
-
-export {
-	Entity,
-	Action,
-	Link
-};


### PR DESCRIPTION
This reverts #39 (and #40) for a very odd Babel reason. This will be merged and released as v8.6.1, then this revert will be reverted itself (thus re-introducing the new exports) and will be released as v9.0.0.

The details here are mostly covered in [this StackOverflow post](https://stackoverflow.com/questions/33704714/cant-require-default-export-value-in-babel-6-x/33705077#33705077), but the important part is that Babel stopped including `module.exports = exports.default` in version 6. However, this behaviour could be re-added using the `add-module-exports` plugin, which we're using here. The issue with this is that this only works _when there are no named exports_ - so the second named exports are added, that plugin stops doing anything, and we effectively lose our default export. Instead, we now get an export of

```js
{
  default: [Function: Entity],
  Entity: [Function: Entity],
  Action: [Getter],
  Link: [Getter]
}
```

i.e. the `default` is just a member of the exported object, rather than being an actual default export. This is covered in [this Github issue](https://github.com/babel/babel/issues/2212) (from 2015!), which references [this one with more info](https://github.com/babel/babel/issues/2047), so I guess this was ultimately just kind of a trap that we accidentally left ourselves!